### PR TITLE
Honor ignoreUnknownArgs for short options

### DIFF
--- a/lib/Horde/Argv/Parser.php
+++ b/lib/Horde/Argv/Parser.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2020 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -507,6 +507,8 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
             if (!$option) {
                 if ($this->allowUnknownArgs) {
                     $option = $this->addOption($opt, array('default' => true, 'action' => 'append'));
+                } elseif ($this->ignoreUnknownArgs) {
+                    continue;
                 } else {
                     throw new Horde_Argv_BadOptionException($opt);
                 }


### PR DESCRIPTION
Make the partser honor the ignoreUnknownArgs flag for short options, too

While ignoreUnknownArgs used to work for ignoring unknown long options, unknown short options would make the parser complain even when ignoreUnknownArgs was set. This breaks for situations where I would first separate any options from positional arguments (and maybe process global options like --help, --verbose, -h, -v) and later parse again after determining which module(s) should provide further options.