### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Argv/HelpFormatter.php
+++ b/lib/Horde/Argv/HelpFormatter.php
@@ -65,6 +65,7 @@
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/bsd BSD
  */
+#[\AllowDynamicProperties]
 abstract class Horde_Argv_HelpFormatter
 {
     const NO_DEFAULT_VALUE = 'none';

--- a/lib/Horde/Argv/Option.php
+++ b/lib/Horde/Argv/Option.php
@@ -40,6 +40,7 @@
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/bsd BSD
  */
+#[\AllowDynamicProperties]
 class Horde_Argv_Option
 {
     const SUPPRESS_HELP = 'SUPPRESS HELP';

--- a/lib/Horde/Argv/OptionException.php
+++ b/lib/Horde/Argv/OptionException.php
@@ -25,6 +25,7 @@
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/bsd BSD
  */
+#[\AllowDynamicProperties]
 class Horde_Argv_OptionException extends Horde_Argv_Exception
 {
     public function __construct($msg, $option = null)

--- a/lib/Horde/Argv/OptionGroup.php
+++ b/lib/Horde/Argv/OptionGroup.php
@@ -25,6 +25,7 @@
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/bsd BSD
  */
+#[\AllowDynamicProperties]
 class Horde_Argv_OptionGroup extends Horde_Argv_OptionContainer
 {
     protected $_title;

--- a/lib/Horde/Argv/Parser.php
+++ b/lib/Horde/Argv/Parser.php
@@ -79,6 +79,7 @@
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/bsd BSD
  */
+#[\AllowDynamicProperties]
 class Horde_Argv_Parser extends Horde_Argv_OptionContainer
 {
     public $standardOptionList = array();

--- a/lib/Horde/Argv/Values.php
+++ b/lib/Horde/Argv/Values.php
@@ -42,31 +42,37 @@ class Horde_Argv_Values implements IteratorAggregate, ArrayAccess, Countable
         return implode(', ', $str);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($attr)
     {
         return isset($this->$attr) && !is_null($this->$attr);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($attr)
     {
         return $this->$attr;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($attr, $val)
     {
         $this->$attr = $val;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($attr)
     {
         unset($this->$attr);
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator(get_object_vars($this));
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count(get_object_vars($this));

--- a/lib/Horde/Argv/Values.php
+++ b/lib/Horde/Argv/Values.php
@@ -24,6 +24,7 @@
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/bsd BSD
  */
+#[\AllowDynamicProperties]
 class Horde_Argv_Values implements IteratorAggregate, ArrayAccess, Countable
 {
     public function __construct($defaults = array())

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Argv/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Argv/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Argv Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Argv/BoolTest.php
+++ b/test/Horde/Argv/BoolTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_BoolTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/BoolTest.php
+++ b/test/Horde/Argv/BoolTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_BoolTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $options = array(

--- a/test/Horde/Argv/CallbackCheckAbbrevTest.php
+++ b/test/Horde/Argv/CallbackCheckAbbrevTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_CallbackCheckAbbrevTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_Parser();

--- a/test/Horde/Argv/CallbackCheckAbbrevTest.php
+++ b/test/Horde/Argv/CallbackCheckAbbrevTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_CallbackCheckAbbrevTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/CallbackExtraArgsTest.php
+++ b/test/Horde/Argv/CallbackExtraArgsTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_CallbackExtraArgsTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/CallbackExtraArgsTest.php
+++ b/test/Horde/Argv/CallbackExtraArgsTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_CallbackExtraArgsTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $options = array(

--- a/test/Horde/Argv/CallbackManyArgsTest.php
+++ b/test/Horde/Argv/CallbackManyArgsTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_CallbackManyArgsTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/CallbackManyArgsTest.php
+++ b/test/Horde/Argv/CallbackManyArgsTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_CallbackManyArgsTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $options = array(

--- a/test/Horde/Argv/CallbackMeddleArgsTest.php
+++ b/test/Horde/Argv/CallbackMeddleArgsTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_CallbackMeddleArgsTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/CallbackMeddleArgsTest.php
+++ b/test/Horde/Argv/CallbackMeddleArgsTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_CallbackMeddleArgsTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $options = array();

--- a/test/Horde/Argv/CallbackTest.php
+++ b/test/Horde/Argv/CallbackTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_CallbackTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/CallbackTest.php
+++ b/test/Horde/Argv/CallbackTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_CallbackTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $options = array(

--- a/test/Horde/Argv/CallbackVarArgsTest.php
+++ b/test/Horde/Argv/CallbackVarArgsTest.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/InterceptingParser.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_CallbackVarArgsTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/CallbackVarArgsTest.php
+++ b/test/Horde/Argv/CallbackVarArgsTest.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/InterceptingParser.php';
 
 class Horde_Argv_CallbackVarArgsTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $options = array(

--- a/test/Horde/Argv/ChoiceTest.php
+++ b/test/Horde/Argv/ChoiceTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_ChoiceTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_InterceptingParser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE));

--- a/test/Horde/Argv/ChoiceTest.php
+++ b/test/Horde/Argv/ChoiceTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_ChoiceTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/ConflictOverrideTest.php
+++ b/test/Horde/Argv/ConflictOverrideTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_ConflictOverrideTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/ConflictOverrideTest.php
+++ b/test/Horde/Argv/ConflictOverrideTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_ConflictOverrideTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_InterceptingParser(array(

--- a/test/Horde/Argv/ConflictResolveTest.php
+++ b/test/Horde/Argv/ConflictResolveTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/ConflictTestCase.php';
 
 class Horde_Argv_ConflictResolveTest extends Horde_Argv_ConflictTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser->setConflictHandler('resolve');

--- a/test/Horde/Argv/ConflictTestCase.php
+++ b/test/Horde/Argv/ConflictTestCase.php
@@ -7,7 +7,7 @@
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_ConflictTestCase extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/ConflictTestCase.php
+++ b/test/Horde/Argv/ConflictTestCase.php
@@ -10,7 +10,7 @@
 
 class Horde_Argv_ConflictTestCase extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $options = array(new Horde_Argv_Option('-v', '--verbose', array(
             'action' => 'count',

--- a/test/Horde/Argv/ConflictingDefaultsTest.php
+++ b/test/Horde/Argv/ConflictingDefaultsTest.php
@@ -14,6 +14,7 @@ require_once __DIR__ . '/TestCase.php';
 /**
  * Conflicting default values: the last one should win.
  */
+#[\AllowDynamicProperties]
 class Horde_Argv_ConflictingDefaultsTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/ConflictingDefaultsTest.php
+++ b/test/Horde/Argv/ConflictingDefaultsTest.php
@@ -16,7 +16,7 @@ require_once __DIR__ . '/TestCase.php';
  */
 class Horde_Argv_ConflictingDefaultsTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $options = array(

--- a/test/Horde/Argv/CountTest.php
+++ b/test/Horde/Argv/CountTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_CountTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_InterceptingParser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE));

--- a/test/Horde/Argv/CountTest.php
+++ b/test/Horde/Argv/CountTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_CountTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/DefaultValuesTest.php
+++ b/test/Horde/Argv/DefaultValuesTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_DefaultValuesTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_Parser();

--- a/test/Horde/Argv/DefaultValuesTest.php
+++ b/test/Horde/Argv/DefaultValuesTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_DefaultValuesTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/ExpandDefaultsTest.php
+++ b/test/Horde/Argv/ExpandDefaultsTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_ExpandDefaultsTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/ExpandDefaultsTest.php
+++ b/test/Horde/Argv/ExpandDefaultsTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_ExpandDefaultsTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_Parser(array(

--- a/test/Horde/Argv/ExtendAddActionsTest.php
+++ b/test/Horde/Argv/ExtendAddActionsTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_ExtendAddActionsTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $options = array(new Horde_Argv_ExtendAddActionsTest_MyOption("-a", "--apple", array(

--- a/test/Horde/Argv/ExtendAddActionsTest.php
+++ b/test/Horde/Argv/ExtendAddActionsTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_ExtendAddActionsTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/ExtendAddTypesTest.php
+++ b/test/Horde/Argv/ExtendAddTypesTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_ExtendAddTypesTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_InterceptingParser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE,
@@ -25,7 +25,7 @@ class Horde_Argv_ExtendAddTypesTest extends Horde_Argv_TestCase
         $this->testPath = tempnam('/tmp', 'horde_argv');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (!is_link($this->testPath) && is_dir($this->testPath)) {
             rmdir($this->testPath);

--- a/test/Horde/Argv/ExtendAddTypesTest.php
+++ b/test/Horde/Argv/ExtendAddTypesTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_ExtendAddTypesTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/HelpTest.php
+++ b/test/Horde/Argv/HelpTest.php
@@ -59,7 +59,7 @@ Options:
   -h, --help         show this help message and exit
 ';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = $this->makeParser(80);
@@ -69,7 +69,7 @@ Options:
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         putenv('COLUMNS=' . $this->origColumns);
         unset($_SERVER['argv']);

--- a/test/Horde/Argv/HelpTest.php
+++ b/test/Horde/Argv/HelpTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_HelpTest extends Horde_Argv_TestCase
 {
 

--- a/test/Horde/Argv/InterceptedException.php
+++ b/test/Horde/Argv/InterceptedException.php
@@ -7,7 +7,7 @@
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_InterceptedException extends Exception
 {
     public function __construct($error_message = null, $exit_status = null, $exit_message = null)

--- a/test/Horde/Argv/MultipleArgsAppendTest.php
+++ b/test/Horde/Argv/MultipleArgsAppendTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_MultipleArgsAppendTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/MultipleArgsAppendTest.php
+++ b/test/Horde/Argv/MultipleArgsAppendTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_MultipleArgsAppendTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_InterceptingParser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE));

--- a/test/Horde/Argv/MultipleArgsTest.php
+++ b/test/Horde/Argv/MultipleArgsTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_MultipleArgsTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/MultipleArgsTest.php
+++ b/test/Horde/Argv/MultipleArgsTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_MultipleArgsTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_InterceptingParser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE));

--- a/test/Horde/Argv/OptionChecksTest.php
+++ b/test/Horde/Argv/OptionChecksTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_OptionChecksTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_Parser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE));

--- a/test/Horde/Argv/OptionChecksTest.php
+++ b/test/Horde/Argv/OptionChecksTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_OptionChecksTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/OptionGroupTest.php
+++ b/test/Horde/Argv/OptionGroupTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_OptionGroupTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_Parser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE));

--- a/test/Horde/Argv/OptionGroupTest.php
+++ b/test/Horde/Argv/OptionGroupTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_OptionGroupTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/ParseNumTest.php
+++ b/test/Horde/Argv/ParseNumTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_ParseNumTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_InterceptingParser();

--- a/test/Horde/Argv/ParseNumTest.php
+++ b/test/Horde/Argv/ParseNumTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_ParseNumTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/ParserTest.php
+++ b/test/Horde/Argv/ParserTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_ParserTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/ParserTest.php
+++ b/test/Horde/Argv/ParserTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_ParserTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_Parser();

--- a/test/Horde/Argv/ProgNameTest.php
+++ b/test/Horde/Argv/ProgNameTest.php
@@ -13,14 +13,14 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_ProgNameTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!isset($_SERVER['argv'])) {
             $_SERVER['argv'] = array('test');
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($_SERVER['argv']);
     }

--- a/test/Horde/Argv/StandardTest.php
+++ b/test/Horde/Argv/StandardTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_StandardTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/StandardTest.php
+++ b/test/Horde/Argv/StandardTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_StandardTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $options = array(

--- a/test/Horde/Argv/TestCase.php
+++ b/test/Horde/Argv/TestCase.php
@@ -8,14 +8,14 @@
  * @subpackage UnitTests
  */
 
-class Horde_Argv_TestCase extends PHPUnit_Framework_TestCase
+class Horde_Argv_TestCase extends Horde_Test_Case
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         setlocale(LC_ALL, 'C');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         setlocale(LC_ALL, '');
     }

--- a/test/Horde/Argv/TypeAliasesTest.php
+++ b/test/Horde/Argv/TypeAliasesTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_TypeAliasesTest extends Horde_Argv_TestCase
 {
     public function setUp(): void

--- a/test/Horde/Argv/TypeAliasesTest.php
+++ b/test/Horde/Argv/TypeAliasesTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_TypeAliasesTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_Parser();

--- a/test/Horde/Argv/VersionTest.php
+++ b/test/Horde/Argv/VersionTest.php
@@ -13,14 +13,14 @@ require_once __DIR__ . '/TestCase.php';
 
 class Horde_Argv_VersionTest extends Horde_Argv_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!isset($_SERVER['argv'])) {
             $_SERVER['argv'] = array('test');
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($_SERVER['argv']);
     }

--- a/test/Horde/Argv/VersionTest.php
+++ b/test/Horde/Argv/VersionTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/TestCase.php';
  * @package    Argv
  * @subpackage UnitTests
  */
-
+#[\AllowDynamicProperties]
 class Horde_Argv_VersionTest extends Horde_Argv_TestCase
 {
     public function setUp(): void


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-argv/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix autopkgtest failure due to php8.1 changes https://salsa.debian.org/horde-team/php-horde-argv/-/blob/debian-sid/debian/patches/2010_phpunit-8.1.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-argv/-/blob/debian-sid/debian/patches/1012_php8.2.patch
