### PR TITLE
chore: modernize code style with PHP 8.2 syntax

### DIFF
--- a/lib/Horde/Argv/AmbiguousOptionException.php
+++ b/lib/Horde/Argv/AmbiguousOptionException.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *

--- a/lib/Horde/Argv/BadOptionException.php
+++ b/lib/Horde/Argv/BadOptionException.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *

--- a/lib/Horde/Argv/Exception.php
+++ b/lib/Horde/Argv/Exception.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -24,6 +25,4 @@
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/bsd BSD
  */
-class Horde_Argv_Exception extends Horde_Exception_Wrapped
-{
-}
+class Horde_Argv_Exception extends Horde_Exception_Wrapped {}

--- a/lib/Horde/Argv/HelpFormatter.php
+++ b/lib/Horde/Argv/HelpFormatter.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -67,7 +68,7 @@
  */
 abstract class Horde_Argv_HelpFormatter
 {
-    const NO_DEFAULT_VALUE = 'none';
+    public const NO_DEFAULT_VALUE = 'none';
 
     public $parser = null;
     public $_color;
@@ -85,10 +86,12 @@ abstract class Horde_Argv_HelpFormatter
     public $short_first;
 
     public function __construct(
-        $indent_increment, $max_help_position, $width = null,
-        $short_first = false, $color = null
-    )
-    {
+        $indent_increment,
+        $max_help_position,
+        $width = null,
+        $short_first = false,
+        $color = null
+    ) {
         if (is_null($color)) {
             $color = new Horde_Cli_Color();
         }
@@ -117,7 +120,7 @@ abstract class Horde_Argv_HelpFormatter
 
     public function setShortOptDelimiter($delim)
     {
-        if (!in_array($delim, array('', ' '))) {
+        if (!in_array($delim, ['', ' '])) {
             throw new InvalidArgumentException('invalid metavar delimiter for short options: ' . $delim);
         }
         $this->_short_opt_fmt = "%s$delim%s";
@@ -125,7 +128,7 @@ abstract class Horde_Argv_HelpFormatter
 
     public function setLongOptDelimiter($delim)
     {
-        if (!in_array($delim, array('=', ' '))) {
+        if (!in_array($delim, ['=', ' '])) {
             throw new InvalidArgumentException('invalid metavar delimiter for long options: ' . $delim);
         }
         $this->_long_opt_fmt = "%s$delim%s";
@@ -197,12 +200,12 @@ abstract class Horde_Argv_HelpFormatter
             return $option->help;
         }
 
-        $default_value = isset($this->parser->defaults[$option->dest]) ? $this->parser->defaults[$option->dest] : null;
+        $default_value = $this->parser->defaults[$option->dest] ?? null;
         if ($default_value == Horde_Argv_Option::$NO_DEFAULT || !$default_value) {
             $default_value = self::NO_DEFAULT_VALUE;
         }
 
-        return str_replace($this->default_tag, (string)$default_value, $option->help);
+        return str_replace($this->default_tag, (string) $default_value, $option->help);
     }
 
     /**
@@ -223,10 +226,9 @@ abstract class Horde_Argv_HelpFormatter
      */
     public function formatOption($option)
     {
-        $result = array();
-        $opts = isset($this->option_strings[(string)$option])
-            ? $this->option_strings[(string)$option]
-            : null;
+        $result = [];
+        $opts = $this->option_strings[(string) $option]
+            ?? null;
         $opt_width = $this->help_position - $this->current_indent - 2;
         if (strlen($opts) > $opt_width) {
             $opts = sprintf(
@@ -250,11 +252,15 @@ abstract class Horde_Argv_HelpFormatter
             $help_text = $this->expandDefault($option);
             $help_lines = explode("\n", wordwrap($help_text, $this->help_width, "\n", true));
             $result[] = sprintf(
-                '%' . $indent_first . "s%s\n", '', $help_lines[0]
+                '%' . $indent_first . "s%s\n",
+                '',
+                $help_lines[0]
             );
             for ($i = 1, $i_max = count($help_lines); $i < $i_max; $i++) {
                 $result[] = sprintf(
-                    '%' . $this->help_position . "s%s\n", '', $help_lines[$i]
+                    '%' . $this->help_position . "s%s\n",
+                    '',
+                    $help_lines[$i]
                 );
             }
         } elseif (substr($opts, -1) != "\n") {
@@ -283,7 +289,7 @@ abstract class Horde_Argv_HelpFormatter
         $max_len = 0;
         foreach ($parser->optionList as $opt) {
             $strings = $this->formatOptionStrings($opt);
-            $this->option_strings[(string)$opt] = $strings;
+            $this->option_strings[(string) $opt] = $strings;
             $max_len = max(
                 $max_len,
                 strlen($strings) + $this->current_indent
@@ -293,7 +299,7 @@ abstract class Horde_Argv_HelpFormatter
         foreach ($parser->optionGroups as $group) {
             foreach ($group->optionList as $opt) {
                 $strings = $this->formatOptionStrings($opt);
-                $this->option_strings[(string)$opt] = $strings;
+                $this->option_strings[(string) $opt] = $strings;
                 $max_len = max(
                     $max_len,
                     strlen($strings)
@@ -314,11 +320,11 @@ abstract class Horde_Argv_HelpFormatter
     {
         if ($option->takesValue()) {
             $metavar = $option->metavar ? $option->metavar : Horde_String::upper($option->dest);
-            $short_opts = array();
+            $short_opts = [];
             foreach ($option->shortOpts as $sopt) {
                 $short_opts[] = sprintf($this->_short_opt_fmt, $sopt, $metavar);
             }
-            $long_opts = array();
+            $long_opts = [];
             foreach ($option->longOpts as $lopt) {
                 $long_opts[] = sprintf($this->_long_opt_fmt, $lopt, $metavar);
             }

--- a/lib/Horde/Argv/IndentedHelpFormatter.php
+++ b/lib/Horde/Argv/IndentedHelpFormatter.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -27,12 +28,18 @@
 class Horde_Argv_IndentedHelpFormatter extends Horde_Argv_HelpFormatter
 {
     public function __construct(
-        $indent_increment = 2, $max_help_position = 24, $width = null,
-        $short_first = true, $color = null
-    )
-    {
+        $indent_increment = 2,
+        $max_help_position = 24,
+        $width = null,
+        $short_first = true,
+        $color = null
+    ) {
         parent::__construct(
-            $indent_increment, $max_help_position, $width, $short_first, $color
+            $indent_increment,
+            $max_help_position,
+            $width,
+            $short_first,
+            $color
         );
     }
 
@@ -48,7 +55,9 @@ class Horde_Argv_IndentedHelpFormatter extends Horde_Argv_HelpFormatter
     public function formatHeading($heading)
     {
         return $this->highlightHeading(sprintf(
-            '%' . $this->current_indent . "s%s:\n", '', $heading
+            '%' . $this->current_indent . "s%s:\n",
+            '',
+            $heading
         ));
     }
 

--- a/lib/Horde/Argv/Option.php
+++ b/lib/Horde/Argv/Option.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -42,14 +43,14 @@
  */
 class Horde_Argv_Option
 {
-    const SUPPRESS_HELP = 'SUPPRESS HELP';
-    const SUPPRESS_USAGE = 'SUPPRESS USAGE';
+    public const SUPPRESS_HELP = 'SUPPRESS HELP';
+    public const SUPPRESS_USAGE = 'SUPPRESS USAGE';
 
     /**
      * Not supplying a default is different from a default of None,
      * so we need an explicit 'not supplied' value.
      */
-    public static $NO_DEFAULT = array('NO', 'DEFAULT');
+    public static $NO_DEFAULT = ['NO', 'DEFAULT'];
 
     public static function parseNumber($value)
     {
@@ -97,25 +98,30 @@ class Horde_Argv_Option
     public function checkBuiltin($opt, $value)
     {
         switch ($this->type) {
-        case 'int':
-        case 'long':
-            $number = self::parseNumber($value);
-            if ($number === false) {
-                $message = $this->type == 'int'
-                    ? Horde_Argv_Translation::t("option %s: invalid integer value: '%s'")
-                    : Horde_Argv_Translation::t("option %s: invalid long integer value: '%s'");
-                throw new Horde_Argv_OptionValueException(
-                    sprintf($message, $opt, $value));
-            }
-            return $number;
+            case 'int':
+            case 'long':
+                $number = self::parseNumber($value);
+                if ($number === false) {
+                    $message = $this->type == 'int'
+                        ? Horde_Argv_Translation::t("option %s: invalid integer value: '%s'")
+                        : Horde_Argv_Translation::t("option %s: invalid long integer value: '%s'");
+                    throw new Horde_Argv_OptionValueException(
+                        sprintf($message, $opt, $value)
+                    );
+                }
+                return $number;
 
-        case 'float':
-            if (!is_numeric($value)) {
-                throw new Horde_Argv_OptionValueException(
-                    sprintf(Horde_Argv_Translation::t("option %s: invalid floating-point value: '%s'"),
-                            $opt, $value));
-            }
-            return floatval($value);
+            case 'float':
+                if (!is_numeric($value)) {
+                    throw new Horde_Argv_OptionValueException(
+                        sprintf(
+                            Horde_Argv_Translation::t("option %s: invalid floating-point value: '%s'"),
+                            $opt,
+                            $value
+                        )
+                    );
+                }
+                return floatval($value);
         }
     }
 
@@ -124,14 +130,17 @@ class Horde_Argv_Option
         if (in_array($value, $this->choices)) {
             return $value;
         } else {
-            $choices = array();
+            $choices = [];
             foreach ($this->choices as $choice) {
-                $choices[] = (string)$choice;
+                $choices[] = (string) $choice;
             }
             $choices = "'" . implode("', '", $choices) . "'";
             throw new Horde_Argv_OptionValueException(sprintf(
                 Horde_Argv_Translation::t("option %s: invalid choice: '%s' (choose from %s)"),
-                $opt, $value, $choices));
+                $opt,
+                $value,
+                $choices
+            ));
         }
     }
 
@@ -140,7 +149,7 @@ class Horde_Argv_Option
      * The list of instance attributes that may be set through keyword args to
      * the constructor.
      */
-    public $ATTRS = array(
+    public $ATTRS = [
         'action',
         'type',
         'dest',
@@ -152,13 +161,13 @@ class Horde_Argv_Option
         'callbackArgs',
         'help',
         'metavar',
-    );
+    ];
 
     /**
      * The set of actions allowed by option parsers.  Explicitly listed here so
      * the constructor can validate its arguments.
      */
-    public $ACTIONS = array(
+    public $ACTIONS = [
         'store',
         'store_const',
         'store_true',
@@ -169,14 +178,14 @@ class Horde_Argv_Option
         'callback',
         'help',
         'version',
-    );
+    ];
 
     /**
      * The set of actions that involve storing a value somewhere;
      * also listed just for constructor argument validation.  (If
      * the action is one of these, there must be a destination.)
      */
-    public $STORE_ACTIONS = array(
+    public $STORE_ACTIONS = [
         'store',
         'store_const',
         'store_true',
@@ -184,35 +193,35 @@ class Horde_Argv_Option
         'append',
         'append_const',
         'count',
-    );
+    ];
 
     /**
      * The set of actions for which it makes sense to supply a value type,
      * ie. which may consume an argument from the command line.
      */
-    public $TYPED_ACTIONS = array(
+    public $TYPED_ACTIONS = [
         'store',
         'append',
         'callback',
-    );
+    ];
 
     /**
      * The set of actions which *require* a value type, ie. that always consume
      * an argument from the command line.
      */
-    public $ALWAYS_TYPED_ACTIONS = array('store', 'append');
+    public $ALWAYS_TYPED_ACTIONS = ['store', 'append'];
 
     /**
      * The set of actions which take a 'const' attribute.
      */
-    public $CONST_ACTIONS = array('store_const', 'append_const');
+    public $CONST_ACTIONS = ['store_const', 'append_const'];
 
     /**
      * The set of known types for option parsers.
      *
      * Again, listed here for constructor argument validation.
      */
-    public $TYPES = array('string', 'int', 'long', 'float', 'complex', 'choice');
+    public $TYPES = ['string', 'int', 'long', 'float', 'complex', 'choice'];
 
     /**
      * Dictionary of argument checking functions, which convert and validate
@@ -235,12 +244,12 @@ class Horde_Argv_Option
      * If no checker is defined for a type, arguments will be unchecked and
      * remain strings.
      */
-    public $TYPE_CHECKER = array('int'     => 'checkBuiltin',
-                                 'long'    => 'checkBuiltin',
-                                 'float'   => 'checkBuiltin',
-                                 'complex' => 'checkBuiltin',
-                                 'choice'  => 'checkChoice',
-    );
+    public $TYPE_CHECKER = ['int'     => 'checkBuiltin',
+        'long'    => 'checkBuiltin',
+        'float'   => 'checkBuiltin',
+        'complex' => 'checkBuiltin',
+        'choice'  => 'checkChoice',
+    ];
 
     /**
      * A list of unbound method objects.
@@ -252,14 +261,14 @@ class Horde_Argv_Option
      * that add another _check_*() method should define their own CHECK_METHODS
      * list that adds their check method to those from this class.
      */
-    public $CHECK_METHODS = array('_checkAction',
-                                  '_checkType',
-                                  '_checkChoice',
-                                  '_checkDest',
-                                  '_checkConst',
-                                  '_checkNargs',
-                                  '_checkCallback',
-    );
+    public $CHECK_METHODS = ['_checkAction',
+        '_checkType',
+        '_checkChoice',
+        '_checkDest',
+        '_checkConst',
+        '_checkNargs',
+        '_checkCallback',
+    ];
 
     // -- Constructor/initialization methods ----------------------------
 
@@ -289,15 +298,15 @@ class Horde_Argv_Option
         $opts = func_get_args();
         $num = func_num_args();
         if ($num == 0 || $num == 1 || !is_array($opts[$num - 1])) {
-            $attrs = array();
+            $attrs = [];
         } else {
             $attrs = array_pop($opts);
         }
 
         // Set shortOpts, longOpts attrs from 'opts' tuple.
         // Have to be set now, in case no option strings are supplied.
-        $this->shortOpts = array();
-        $this->longOpts = array();
+        $this->shortOpts = [];
+        $this->longOpts = [];
         $opts = $this->_checkOptStrings($opts);
         $this->_setOptStrings($opts);
 
@@ -310,7 +319,7 @@ class Horde_Argv_Option
         // could be handy for subclasses!  The one thing these all share
         // is that they raise OptionError if they discover a problem.
         foreach ($this->CHECK_METHODS as $checker) {
-            call_user_func(array($this, $checker));
+            call_user_func([$this, $checker]);
         }
     }
 
@@ -329,22 +338,26 @@ class Horde_Argv_Option
     protected function _setOptStrings($opts)
     {
         foreach ($opts as &$opt) {
-            $opt = (string)$opt;
+            $opt = (string) $opt;
 
             if (strlen($opt) < 2) {
                 throw new Horde_Argv_OptionException(sprintf("invalid option string '%s': must be at least two characters long", $opt), $this);
             } elseif (strlen($opt) == 2) {
                 if (!($opt[0] == '-' && $opt[1] != '-')) {
                     throw new Horde_Argv_OptionException(sprintf(
-                        "invalid short option string '%s': " .
-                        "must be of the form -x, (x any non-dash char)", $opt), $this);
+                        "invalid short option string '%s': "
+                        . "must be of the form -x, (x any non-dash char)",
+                        $opt
+                    ), $this);
                 }
                 $this->shortOpts[] = $opt;
             } else {
                 if (!(substr($opt, 0, 2) == '--' && $opt[2] != '-')) {
                     throw new Horde_Argv_OptionException(sprintf(
-                        "invalid long option string '%s': " .
-                        "must start with --, followed by non-dash", $opt), $this);
+                        "invalid long option string '%s': "
+                        . "must start with --, followed by non-dash",
+                        $opt
+                    ), $this);
                 }
                 $this->longOpts[] = $opt;
             }
@@ -370,7 +383,9 @@ class Horde_Argv_Option
             $attrs = array_keys($attrs);
             sort($attrs);
             throw new Horde_Argv_OptionException(sprintf(
-                'invalid keyword arguments: %s', implode(', ', $attrs)), $this);
+                'invalid keyword arguments: %s',
+                implode(', ', $attrs)
+            ), $this);
         }
     }
 
@@ -409,7 +424,9 @@ class Horde_Argv_Option
 
             if (!in_array($this->action, $this->TYPED_ACTIONS)) {
                 throw new Horde_Argv_OptionException(sprintf(
-                    "must not supply a type for action '%s'", $this->action), $this);
+                    "must not supply a type for action '%s'",
+                    $this->action
+                ), $this);
             }
         }
     }
@@ -419,15 +436,20 @@ class Horde_Argv_Option
         if ($this->type == 'choice') {
             if (is_null($this->choices)) {
                 throw new Horde_Argv_OptionException(
-                    "must supply a list of choices for type 'choice'", $this);
+                    "must supply a list of choices for type 'choice'",
+                    $this
+                );
             } elseif (!(is_array($this->choices) || $this->choices instanceof Iterator)) {
                 throw new Horde_Argv_OptionException(sprintf(
                     "choices must be a list of strings ('%s' supplied)",
-                    gettype($this->choices)), $this);
+                    gettype($this->choices)
+                ), $this);
             }
         } elseif (!is_null($this->choices)) {
             throw new Horde_Argv_OptionException(sprintf(
-                "must not supply choices for type '%s'", $this->type), $this);
+                "must not supply choices for type '%s'",
+                $this->type
+            ), $this);
         }
     }
 
@@ -435,8 +457,8 @@ class Horde_Argv_Option
     {
         // No destination given, and we need one for this action.  The
         // $this->type check is for callbacks that take a value.
-        $takes_value = (in_array($this->action, $this->STORE_ACTIONS) ||
-                        !is_null($this->type));
+        $takes_value = (in_array($this->action, $this->STORE_ACTIONS)
+                        || !is_null($this->type));
         if (is_null($this->dest) && $takes_value) {
             // Glean a destination from the first long option string,
             // or from the first short option string if no long options.
@@ -452,9 +474,13 @@ class Horde_Argv_Option
     public function _checkConst()
     {
         if (!in_array($this->action, $this->CONST_ACTIONS) && !is_null($this->const)) {
-            throw new Horde_Argv_OptionException(sprintf(
-                "'const' must not be supplied for action '%s'", $this->action),
-                $this);
+            throw new Horde_Argv_OptionException(
+                sprintf(
+                    "'const' must not be supplied for action '%s'",
+                    $this->action
+                ),
+                $this
+            );
         }
     }
 
@@ -465,9 +491,13 @@ class Horde_Argv_Option
                 $this->nargs = 1;
             }
         } elseif (!is_null($this->nargs)) {
-            throw new Horde_Argv_OptionException(sprintf(
-                "'nargs' must not be supplied for action '%s'", $this->action),
-                $this);
+            throw new Horde_Argv_OptionException(
+                sprintf(
+                    "'nargs' must not be supplied for action '%s'",
+                    $this->action
+                ),
+                $this
+            );
         }
     }
 
@@ -475,29 +505,35 @@ class Horde_Argv_Option
     {
         if ($this->action == 'callback') {
             if (!is_callable($this->callback)) {
-                $callback_name = is_array($this->callback) ?
-                    is_object($this->callback[0]) ? get_class($this->callback[0] . '#' . $this->callback[1]) : implode('#', $this->callback) :
-                    $this->callback;
+                $callback_name = is_array($this->callback)
+                    ? is_object($this->callback[0]) ? get_class($this->callback[0] . '#' . $this->callback[1]) : implode('#', $this->callback)
+                    : $this->callback;
                 throw new Horde_Argv_OptionException(sprintf(
-                    "callback not callable: '%s'", $callback_name), $this);
+                    "callback not callable: '%s'",
+                    $callback_name
+                ), $this);
             }
             if (!is_null($this->callbackArgs) && !is_array($this->callbackArgs)) {
                 throw new Horde_Argv_OptionException(sprintf(
                     "callbackArgs, if supplied, must be an array: not '%s'",
-                    $this->callbackArgs), $this);
+                    $this->callbackArgs
+                ), $this);
             }
         } else {
             if (!is_null($this->callback)) {
-                $callback_name = is_array($this->callback) ?
-                    is_object($this->callback[0]) ? get_class($this->callback[0] . '#' . $this->callback[1]) : implode('#', $this->callback) :
-                    $this->callback;
+                $callback_name = is_array($this->callback)
+                    ? is_object($this->callback[0]) ? get_class($this->callback[0] . '#' . $this->callback[1]) : implode('#', $this->callback)
+                    : $this->callback;
                 throw new Horde_Argv_OptionException(sprintf(
                     "callback supplied ('%s') for non-callback option",
-                    $callback_name), $this);
+                    $callback_name
+                ), $this);
             }
             if (!is_null($this->callbackArgs)) {
                 throw new Horde_Argv_OptionException(
-                    'callbackArgs supplied for non-callback option', $this);
+                    'callbackArgs supplied for non-callback option',
+                    $this
+                );
             }
         }
     }
@@ -538,7 +574,7 @@ class Horde_Argv_Option
             return $value;
         }
         $checker = $this->TYPE_CHECKER[$this->type];
-        return call_user_func(array($this, $checker), $opt, $value);
+        return call_user_func([$this, $checker], $opt, $value);
     }
 
     public function convertValue($opt, $value)
@@ -547,7 +583,7 @@ class Horde_Argv_Option
             if ($this->nargs == 1) {
                 return $this->checkValue($opt, $value);
             } else {
-                $return = array();
+                $return = [];
                 foreach ($value as $v) {
                     $return[] = $this->checkValue($opt, $v);
                 }
@@ -566,7 +602,13 @@ class Horde_Argv_Option
         // This is a separate method to make life easier for
         // subclasses to add new actions.
         return $this->takeAction(
-            $this->action, $this->dest, $opt, $value, $values, $parser);
+            $this->action,
+            $this->dest,
+            $opt,
+            $value,
+            $values,
+            $parser
+        );
     }
 
     public function takeAction($action, $dest, $opt, $value, $values, $parser)

--- a/lib/Horde/Argv/OptionConflictException.php
+++ b/lib/Horde/Argv/OptionConflictException.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -24,5 +25,4 @@
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/bsd BSD
  */
-class Horde_Argv_OptionConflictException extends Horde_Argv_OptionException
-{}
+class Horde_Argv_OptionConflictException extends Horde_Argv_OptionException {}

--- a/lib/Horde/Argv/OptionContainer.php
+++ b/lib/Horde/Argv/OptionContainer.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -52,11 +53,11 @@
 class Horde_Argv_OptionContainer
 {
     public $description = '';
-    public $optionList = array();
+    public $optionList = [];
     public $optionClass = 'Horde_Argv_Option';
-    public $defaults = array();
-    public $shortOpt = array();
-    public $longOpt = array();
+    public $defaults = [];
+    public $shortOpt = [];
+    public $longOpt = [];
     public $conflictHandler;
 
     /**
@@ -81,9 +82,9 @@ class Horde_Argv_OptionContainer
      */
     protected function _createOptionMappings()
     {
-        $this->shortOpt = array();       // single letter -> Option instance
-        $this->longOpt = array();        // long option -> Option instance
-        $this->defaults = array();       // maps option dest -> default value
+        $this->shortOpt = [];       // single letter -> Option instance
+        $this->longOpt = [];        // long option -> Option instance
+        $this->defaults = [];       // maps option dest -> default value
     }
 
     /**
@@ -92,14 +93,14 @@ class Horde_Argv_OptionContainer
      */
     protected function _shareOptionMappings($parser)
     {
-        $this->shortOpt =& $parser->shortOpt;
-        $this->longOpt =& $parser->longOpt;
+        $this->shortOpt = & $parser->shortOpt;
+        $this->longOpt = & $parser->longOpt;
         $this->defaults = $parser->defaults;
     }
 
     public function setConflictHandler($handler)
     {
-        if (!in_array($handler, array('error', 'resolve'))) {
+        if (!in_array($handler, ['error', 'resolve'])) {
             throw new InvalidArgumentException('invalid conflictHandler ' . var_export($handler, true));
         }
         $this->conflictHandler = $handler;
@@ -119,7 +120,7 @@ class Horde_Argv_OptionContainer
 
     protected function _checkConflict($option)
     {
-        $conflictOpts = array();
+        $conflictOpts = [];
         foreach ($option->shortOpts as $opt) {
             if (isset($this->shortOpt[$opt])) {
                 $conflictOpts[$opt] = $this->shortOpt[$opt];
@@ -136,7 +137,8 @@ class Horde_Argv_OptionContainer
             if ($handler == 'error') {
                 throw new Horde_Argv_OptionConflictException(sprintf(
                     'conflicting option string(s): %s',
-                    implode(', ', array_keys($conflictOpts))), $option);
+                    implode(', ', array_keys($conflictOpts))
+                ), $option);
             } elseif ($handler == 'resolve') {
                 foreach ($conflictOpts as $opt => $c_option) {
                     if (strncmp($opt, '--', 2) === 0) {
@@ -171,8 +173,9 @@ class Horde_Argv_OptionContainer
             $option = $optionFactory->newInstanceArgs($opts);
         } elseif (count($opts) == 1) {
             $option = $opts[0];
-            if (!$option instanceof Horde_Argv_Option)
+            if (!$option instanceof Horde_Argv_Option) {
                 throw new InvalidArgumentException('not an Option instance: ' . var_export($option, true));
+            }
         } else {
             throw new InvalidArgumentException('invalid arguments');
         }
@@ -248,12 +251,14 @@ class Horde_Argv_OptionContainer
 
     public function formatOptionHelp($formatter = null)
     {
-        if (!$this->optionList)
+        if (!$this->optionList) {
             return '';
-        $result = array();
+        }
+        $result = [];
         foreach ($this->optionList as $option) {
-            if ($option->help != Horde_Argv_Option::SUPPRESS_HELP)
+            if ($option->help != Horde_Argv_Option::SUPPRESS_HELP) {
                 $result[] = $formatter->formatOption($option);
+            }
         }
         return implode('', $result);
     }
@@ -265,11 +270,13 @@ class Horde_Argv_OptionContainer
 
     public function formatHelp($formatter = null)
     {
-        $result = array();
-        if ($this->description)
+        $result = [];
+        if ($this->description) {
             $result[] = $this->formatDescription($formatter);
-        if ($this->optionList)
+        }
+        if ($this->optionList) {
             $result[] = $this->formatOptionHelp($formatter);
+        }
         return implode("\n", $result);
     }
 

--- a/lib/Horde/Argv/OptionException.php
+++ b/lib/Horde/Argv/OptionException.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -31,7 +32,7 @@ class Horde_Argv_OptionException extends Horde_Argv_Exception
 
     public function __construct($msg, $option = null)
     {
-        $this->optionId = (string)$option;
+        $this->optionId = (string) $option;
         if ($this->optionId) {
             parent::__construct(sprintf('option %s: %s', $this->optionId, $msg));
         } else {

--- a/lib/Horde/Argv/OptionGroup.php
+++ b/lib/Horde/Argv/OptionGroup.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -39,7 +40,7 @@ class Horde_Argv_OptionGroup extends Horde_Argv_OptionContainer
 
     protected function _createOptionList()
     {
-        $this->optionList = array();
+        $this->optionList = [];
         $this->_shareOptionMappings($this->parser);
     }
 
@@ -57,8 +58,9 @@ class Horde_Argv_OptionGroup extends Horde_Argv_OptionContainer
 
     public function formatHelp($formatter = null)
     {
-        if (is_null($formatter))
+        if (is_null($formatter)) {
             return '';
+        }
 
         $result = $formatter->formatHeading($this->_title);
         $formatter->indent();

--- a/lib/Horde/Argv/OptionValueException.php
+++ b/lib/Horde/Argv/OptionValueException.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -24,5 +25,4 @@
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/bsd BSD
  */
-class Horde_Argv_OptionValueException extends Horde_Argv_OptionException
-{}
+class Horde_Argv_OptionValueException extends Horde_Argv_OptionException {}

--- a/lib/Horde/Argv/Parser.php
+++ b/lib/Horde/Argv/Parser.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2020 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -131,8 +132,10 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
         // standardOptionList class attribute, the 'optionList'
         // argument, and (if applicable) the _addVersionOption() and
         // _addHelpOption() methods.
-        $this->_populateOptionList($args['optionList'],
-                                   $args['addHelpOption']);
+        $this->_populateOptionList(
+            $args['optionList'],
+            $args['addHelpOption']
+        );
 
         $this->_initParsingState();
     }
@@ -149,26 +152,30 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
 
     protected function _addHelpOption()
     {
-        $this->addOption('-h', '--help', array('action' => 'help',
-                                               'help' => Horde_Argv_Translation::t("show this help message and exit")));
+        $this->addOption('-h', '--help', ['action' => 'help',
+            'help' => Horde_Argv_Translation::t("show this help message and exit")]);
     }
 
     protected function _addVersionOption()
     {
-        $this->addOption('--version', array('action' => 'version',
-                                            'help' => Horde_Argv_Translation::t("show program's version number and exit")));
+        $this->addOption('--version', ['action' => 'version',
+            'help' => Horde_Argv_Translation::t("show program's version number and exit")]);
     }
 
     protected function _populateOptionList($optionList, $add_help = true)
     {
-        if ($this->standardOptionList)
+        if ($this->standardOptionList) {
             $this->addOptions($this->standardOptionList);
-        if ($optionList)
+        }
+        if ($optionList) {
             $this->addOptions($optionList);
-        if ($this->version)
+        }
+        if ($this->version) {
             $this->_addVersionOption();
-        if ($add_help)
+        }
+        if ($add_help) {
             $this->_addHelpOption();
+        }
     }
 
     protected function _initParsingState()
@@ -183,12 +190,13 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
 
     public function setUsage($usage)
     {
-        if (is_null($usage))
+        if (is_null($usage)) {
             $this->_usage = '%prog ' . Horde_Argv_Translation::t("[options]");
-        elseif ($usage == Horde_Argv_Option::SUPPRESS_USAGE)
+        } elseif ($usage == Horde_Argv_Option::SUPPRESS_USAGE) {
             $this->_usage = '';
-        else
+        } else {
             $this->_usage = $usage;
+        }
     }
 
     public function enableInterspersedArgs()
@@ -224,7 +232,7 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
     {
         $defaults = $this->defaults;
         foreach ($this->_getAllOptions() as $option) {
-            $default = isset($defaults[$option->dest]) ? $defaults[$option->dest] : null;
+            $default = $defaults[$option->dest] ?? null;
             if (is_string($default)) {
                 $opt_str = $option->getOptString();
                 $defaults[$option->dest] = $option->checkValue($opt_str, $default);
@@ -248,10 +256,12 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
             $group = $groupFactory->newInstanceArgs($args);
         } elseif (count($args) == 1) {
             $group = $args[0];
-            if (!$group instanceof Horde_Argv_OptionGroup)
+            if (!$group instanceof Horde_Argv_OptionGroup) {
                 throw new InvalidArgumentException("not an OptionGroup instance: " . var_export($group, true));
-            if ($group->parser !== $this)
+            }
+            if ($group->parser !== $this) {
                 throw new InvalidArgumentException("invalid OptionGroup (wrong parser)");
+            }
         } else {
             throw new InvalidArgumentException('invalid arguments');
         }
@@ -303,9 +313,10 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
     public function parseArgs($args = null, $values = null)
     {
         $rargs = $this->_getArgs($args);
-        $largs = array();
-        if (is_null($values))
+        $largs = [];
+        if (is_null($values)) {
             $values = $this->getDefaultValues();
+        }
 
         // Store the halves of the argument list as attributes for the
         // convenience of callbacks:
@@ -316,8 +327,8 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
         //     the leftover arguments -- ie. what's left after removing
         //     options and their arguments (the "l" stands for "leftover"
         //     or "left-hand")
-        $this->rargs =& $rargs;
-        $this->largs =& $largs;
+        $this->rargs = & $rargs;
+        $this->largs = & $largs;
         $this->values = $values;
 
         try {
@@ -341,7 +352,7 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
      */
     public function checkValues($values, $args)
     {
-        return array($values, $args);
+        return [$values, $args];
     }
 
     /**
@@ -428,7 +439,7 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
         }
 
         // Isolate all words with s as a prefix.
-        $possibilities = array();
+        $possibilities = [];
         foreach (array_keys($wordmap) as $word) {
             if (strncmp($word, $s, strlen($s)) === 0) {
                 $possibilities[] = $word;
@@ -454,7 +465,7 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
         // Value explicitly attached to arg?  Pretend it's the next
         // argument.
         if (strpos($arg, '=') !== false) {
-            list($opt, $next_arg) = explode('=', $arg, 2);
+            [$opt, $next_arg] = explode('=', $arg, 2);
             array_unshift($rargs, $next_arg);
             $had_explicit_value = true;
         } else {
@@ -470,7 +481,7 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
                 return;
             }
             if ($this->allowUnknownArgs) {
-                $option = $this->addOption($opt, array('default' => true, 'action' => 'append'));
+                $option = $this->addOption($opt, ['default' => true, 'action' => 'append']);
             } else {
                 throw $e;
             }
@@ -510,12 +521,12 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
         for ($c = 1, $c_max = strlen($arg); $c < $c_max; $c++) {
             $ch = $arg[$c];
             $opt = '-' . $ch;
-            $option = isset($this->shortOpt[$opt]) ? $this->shortOpt[$opt] : null;
+            $option = $this->shortOpt[$opt] ?? null;
             $i++; // we have consumed a character
 
             if (!$option) {
                 if ($this->allowUnknownArgs) {
-                    $option = $this->addOption($opt, array('default' => true, 'action' => 'append'));
+                    $option = $this->addOption($opt, ['default' => true, 'action' => 'append']);
                 } elseif ($this->ignoreUnknownArgs) {
                     continue;
                 } else {
@@ -553,7 +564,9 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
 
             $option->process($opt, $value, $values, $this);
 
-            if ($stop) { break; }
+            if ($stop) {
+                break;
+            }
         }
     }
 
@@ -561,10 +574,11 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
 
     public function getProgName()
     {
-        if (is_null($this->prog))
+        if (is_null($this->prog)) {
             return basename($_SERVER['argv'][0]);
-        else
+        } else {
             return $this->prog;
+        }
     }
 
     public function expandProgName($s)
@@ -579,8 +593,9 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
 
     public function parserExit($status = 0, $msg = null)
     {
-        if ($msg)
+        if ($msg) {
             fwrite(STDERR, $msg);
+        }
         exit($status);
     }
 
@@ -599,12 +614,14 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
 
     public function getUsage($formatter = null)
     {
-        if (is_null($formatter))
+        if (is_null($formatter)) {
             $formatter = $this->formatter;
-        if ($this->_usage)
+        }
+        if ($this->_usage) {
             return $formatter->formatUsage($this->expandProgName($this->_usage));
-        else
+        } else {
             return '';
+        }
     }
 
     /**
@@ -618,21 +635,24 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
      */
     public function printUsage($file = null)
     {
-        if (!$this->_usage)
+        if (!$this->_usage) {
             return;
+        }
 
-        if (is_null($file))
+        if (is_null($file)) {
             echo $this->getUsage();
-        else
+        } else {
             fwrite($file, $this->getUsage());
+        }
     }
 
     public function getVersion()
     {
-        if ($this->version)
+        if ($this->version) {
             return $this->expandProgName($this->version);
-        else
+        } else {
             return '';
+        }
     }
 
     /**
@@ -645,21 +665,24 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
      */
     public function printVersion($file = null)
     {
-        if (!$this->version)
+        if (!$this->version) {
             return;
+        }
 
-        if (is_null($file))
+        if (is_null($file)) {
             echo $this->getVersion() . "\n";
-        else
+        } else {
             fwrite($file, $this->getVersion() . "\n");
+        }
     }
 
     public function formatOptionHelp($formatter = null)
     {
-        if (is_null($formatter))
+        if (is_null($formatter)) {
             $formatter = $this->formatter;
+        }
         $formatter->storeOptionStrings($this);
-        $result = array();
+        $result = [];
         $result[] = $formatter->formatHeading(Horde_Argv_Translation::t("Options"));
         $formatter->indent();
         if ($this->optionList) {
@@ -683,13 +706,16 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
 
     public function formatHelp($formatter = null)
     {
-        if (is_null($formatter))
+        if (is_null($formatter)) {
             $formatter = $this->formatter;
-        $result = array();
-        if ($this->_usage)
+        }
+        $result = [];
+        if ($this->_usage) {
             $result[] = $this->getUsage($formatter) . "\n";
-        if ($this->description)
+        }
+        if ($this->description) {
             $result[] = $this->formatDescription($formatter) . "\n";
+        }
         $result[] = $this->formatOptionHelp($formatter);
         $result[] = $this->formatEpilog($formatter);
         return implode('', $result);
@@ -703,10 +729,11 @@ class Horde_Argv_Parser extends Horde_Argv_OptionContainer
      */
     public function printHelp($file = null)
     {
-        if (is_null($file))
+        if (is_null($file)) {
             echo $this->formatHelp();
-        else
+        } else {
             fwrite($file, $this->formatHelp());
+        }
     }
 
 }

--- a/lib/Horde/Argv/TitledHelpFormatter.php
+++ b/lib/Horde/Argv/TitledHelpFormatter.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -27,12 +28,18 @@
 class Horde_Argv_TitledHelpFormatter extends Horde_Argv_HelpFormatter
 {
     public function __construct(
-        $indent_increment = 0, $max_help_position = 24, $width = null,
-        $short_first = false, $color = null
-    )
-    {
+        $indent_increment = 0,
+        $max_help_position = 24,
+        $width = null,
+        $short_first = false,
+        $color = null
+    ) {
         parent::__construct(
-            $indent_increment, $max_help_position, $width, $short_first, $color
+            $indent_increment,
+            $max_help_position,
+            $width,
+            $short_first,
+            $color
         );
     }
 
@@ -47,7 +54,7 @@ class Horde_Argv_TitledHelpFormatter extends Horde_Argv_HelpFormatter
 
     public function formatHeading($heading)
     {
-        $prefix = array('=', '-');
+        $prefix = ['=', '-'];
         return $this->highlightHeading(sprintf(
             "%s\n%s\n",
             $heading,

--- a/lib/Horde/Argv/Translation.php
+++ b/lib/Horde/Argv/Translation.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.

--- a/lib/Horde/Argv/Values.php
+++ b/lib/Horde/Argv/Values.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -43,7 +44,7 @@ class Horde_Argv_Values implements IteratorAggregate, ArrayAccess, Countable
 
     /**
      * __set: Set a value
-     * 
+     *
      * @param string $attr The name of the attribute
      * @param mixed $value The content of the attribute
      */
@@ -54,7 +55,7 @@ class Horde_Argv_Values implements IteratorAggregate, ArrayAccess, Countable
 
     /**
      * __get: Returns a value of an attribute
-     * 
+     *
      * @param string $attr The name of the attribute
      * @return mixed       The value of the attribute
      */
@@ -65,7 +66,7 @@ class Horde_Argv_Values implements IteratorAggregate, ArrayAccess, Countable
 
     /**
      * __isset: check if an attribute is set
-     * 
+     *
      * @param string $attr The name of the attribute
      * @return bool        True, when the attribute exists/ is set else false
      */
@@ -73,10 +74,10 @@ class Horde_Argv_Values implements IteratorAggregate, ArrayAccess, Countable
     {
         return isset($this->data[$attr]);
     }
-    
+
     /**
      * __unset: removes a attribute
-     * 
+     *
      * @param string $attr The name of the attribute
      * @return void
      */
@@ -84,17 +85,17 @@ class Horde_Argv_Values implements IteratorAggregate, ArrayAccess, Countable
     {
         unset($this->data[$attr]);
     }
-    
+
     /**
      * __toString: The whole content as a string
-     * 
+     *
      * @return string The content as a string
      */
     public function __toString(): string
     {
         $str = [];
         foreach ($this->data as $attr => $val) {
-            $str[] = $attr . ': ' . (string)$val;
+            $str[] = $attr . ': ' . (string) $val;
         }
         return implode(', ', $str);
     }
@@ -114,7 +115,7 @@ class Horde_Argv_Values implements IteratorAggregate, ArrayAccess, Countable
      * @param mixed $attr
      * @return mixed
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($attr)
     {
         return $this->data[$attr] ?? null;

--- a/src/AmbiguousOptionException.php
+++ b/src/AmbiguousOptionException.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2022 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,7 +15,9 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
+
 /**
  * Raised if an ambiguous option is seen on the command line.
  *

--- a/src/ArgvParser.php
+++ b/src/ArgvParser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Horde\Argv;
 
 /**
@@ -13,6 +14,4 @@ namespace Horde\Argv;
  * @deprecated This interface is under development and not ready for production use.
  *             The API may change without notice. Do not use in production code.
  */
-interface ArgvParser
-{
-}
+interface ArgvParser {}

--- a/src/ArgvWrapper.php
+++ b/src/ArgvWrapper.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Horde\Argv;
 
 use InvalidArgumentException;
@@ -7,6 +9,8 @@ use IteratorAggregate;
 use RuntimeException;
 use Traversable;
 use Countable;
+use ArrayIterator;
+
 /**
  * Wrap a copy of Argv into a simple, typed object for DI
  */
@@ -30,7 +34,7 @@ class ArgvWrapper implements IteratorAggregate, Countable
 
     public function getIterator(): Traversable
     {
-        return new \ArrayIterator($this->argv);
+        return new ArrayIterator($this->argv);
     }
 
     public function count(): int
@@ -40,8 +44,7 @@ class ArgvWrapper implements IteratorAggregate, Countable
 
     public static function fromGlobal()
     {
-        if (empty($GLOBALS['argv']))
-        {
+        if (empty($GLOBALS['argv'])) {
             // Argv always contains at least the binary's name so this indicates a severe error
             throw new RuntimeException("Argv Global is not available or in invalid state");
         }

--- a/src/BadOptionException.php
+++ b/src/BadOptionException.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,7 +15,9 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
+
 /**
  * Raised if an invalid option is seen on the command line.
  *

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,7 +15,9 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
+
 use Horde_Exception_Wrapped;
 
 /**
@@ -27,6 +30,4 @@ use Horde_Exception_Wrapped;
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/bsd BSD
  */
-class Exception extends Horde_Exception_Wrapped
-{
-}
+class Exception extends Horde_Exception_Wrapped {}

--- a/src/HelpFormatter.php
+++ b/src/HelpFormatter.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,7 +15,9 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
+
 use Horde\Cli\Color;
 use Horde\Cli\Cli;
 use Horde\Util\HordeString;
@@ -73,7 +76,7 @@ use InvalidArgumentException;
  */
 abstract class HelpFormatter
 {
-    const NO_DEFAULT_VALUE = 'none';
+    public const NO_DEFAULT_VALUE = 'none';
 
     public $parser = null;
     public $_color;
@@ -91,10 +94,12 @@ abstract class HelpFormatter
     public $short_first;
 
     public function __construct(
-        $indent_increment, $max_help_position, $width = null,
-        $short_first = false, $color = null
-    )
-    {
+        $indent_increment,
+        $max_help_position,
+        $width = null,
+        $short_first = false,
+        $color = null
+    ) {
         if (is_null($color)) {
             $color = new Color();
         }
@@ -111,7 +116,7 @@ abstract class HelpFormatter
         $this->help_width = null; // computed later
         $this->short_first = $short_first;
         $this->default_tag = '%default';
-        $this->option_strings = array();
+        $this->option_strings = [];
         $this->_short_opt_fmt = '%s %s';
         $this->_long_opt_fmt = '%s=%s';
     }
@@ -123,7 +128,7 @@ abstract class HelpFormatter
 
     public function setShortOptDelimiter($delim)
     {
-        if (!in_array($delim, array('', ' '))) {
+        if (!in_array($delim, ['', ' '])) {
             throw new InvalidArgumentException('invalid metavar delimiter for short options: ' . $delim);
         }
         $this->_short_opt_fmt = "%s$delim%s";
@@ -131,7 +136,7 @@ abstract class HelpFormatter
 
     public function setLongOptDelimiter($delim)
     {
-        if (!in_array($delim, array('=', ' '))) {
+        if (!in_array($delim, ['=', ' '])) {
             throw new InvalidArgumentException('invalid metavar delimiter for long options: ' . $delim);
         }
         $this->_long_opt_fmt = "%s$delim%s";
@@ -203,12 +208,12 @@ abstract class HelpFormatter
             return $option->help;
         }
 
-        $default_value = isset($this->parser->defaults[$option->dest]) ? $this->parser->defaults[$option->dest] : null;
+        $default_value = $this->parser->defaults[$option->dest] ?? null;
         if ($default_value == Option::$NO_DEFAULT || !$default_value) {
             $default_value = self::NO_DEFAULT_VALUE;
         }
 
-        return str_replace($this->default_tag, (string)$default_value, $option->help);
+        return str_replace($this->default_tag, (string) $default_value, $option->help);
     }
 
     /**
@@ -229,10 +234,9 @@ abstract class HelpFormatter
      */
     public function formatOption($option)
     {
-        $result = array();
-        $opts = isset($this->option_strings[(string)$option])
-            ? $this->option_strings[(string)$option]
-            : null;
+        $result = [];
+        $opts = $this->option_strings[(string) $option]
+            ?? null;
         $opt_width = $this->help_position - $this->current_indent - 2;
         if (is_string($opts) && strlen($opts) > $opt_width) {
             $opts = sprintf(
@@ -256,11 +260,15 @@ abstract class HelpFormatter
             $help_text = $this->expandDefault($option);
             $help_lines = explode("\n", wordwrap($help_text, (int) $this->help_width, "\n", (bool) $this->help_width));
             $result[] = sprintf(
-                '%' . $indent_first . "s%s\n", '', $help_lines[0]
+                '%' . $indent_first . "s%s\n",
+                '',
+                $help_lines[0]
             );
             for ($i = 1, $i_max = count($help_lines); $i < $i_max; $i++) {
                 $result[] = sprintf(
-                    '%' . $this->help_position . "s%s\n", '', $help_lines[$i]
+                    '%' . $this->help_position . "s%s\n",
+                    '',
+                    $help_lines[$i]
                 );
             }
         } elseif (substr($opts, -1) != "\n") {
@@ -289,7 +297,7 @@ abstract class HelpFormatter
         $max_len = 0;
         foreach ($parser->optionList as $opt) {
             $strings = $this->formatOptionStrings($opt);
-            $this->option_strings[(string)$opt] = $strings;
+            $this->option_strings[(string) $opt] = $strings;
             $max_len = max(
                 $max_len,
                 strlen($strings) + $this->current_indent
@@ -299,7 +307,7 @@ abstract class HelpFormatter
         foreach ($parser->optionGroups as $group) {
             foreach ($group->optionList as $opt) {
                 $strings = $this->formatOptionStrings($opt);
-                $this->option_strings[(string)$opt] = $strings;
+                $this->option_strings[(string) $opt] = $strings;
                 $max_len = max(
                     $max_len,
                     strlen($strings)
@@ -320,11 +328,11 @@ abstract class HelpFormatter
     {
         if ($option->takesValue()) {
             $metavar = $option->metavar ? $option->metavar : HordeString::upper($option->dest);
-            $short_opts = array();
+            $short_opts = [];
             foreach ($option->shortOpts as $sopt) {
                 $short_opts[] = sprintf($this->_short_opt_fmt, $sopt, $metavar);
             }
-            $long_opts = array();
+            $long_opts = [];
             foreach ($option->longOpts as $lopt) {
                 $long_opts[] = sprintf($this->_long_opt_fmt, $lopt, $metavar);
             }

--- a/src/ImmutableParser.php
+++ b/src/ImmutableParser.php
@@ -487,4 +487,16 @@ readonly class ImmutableParser implements ArgvParser
             ->setOptions($this->options)
             ->setGroups($this->groups);
     }
+
+    /**
+     * Format help text.
+     *
+     * @param Modern\Help\HelpFormatter|null $formatter Optional formatter (uses default if null)
+     * @return string Formatted help text
+     */
+    public function formatHelp(?Modern\Help\HelpFormatter $formatter = null): string
+    {
+        $formatter ??= $this->helpFormatter ?? Modern\Help\HelpFormatter::create();
+        return $formatter->format($this->config, $this->options, $this->groups);
+    }
 }

--- a/src/ImmutableParser.php
+++ b/src/ImmutableParser.php
@@ -22,7 +22,9 @@ use Horde\Argv\Modern\Exception\{
     InvalidOptionException,
     AmbiguousOptionException,
     MissingValueException,
-    ConflictingOptionException
+    ConflictingOptionException,
+    UnknownContextException,
+    InvalidArgumentCountException
 };
 use Horde\Argv\Modern\Enum\{OptionAction, ConflictHandler};
 
@@ -78,6 +80,8 @@ readonly class ImmutableParser implements ArgvParser
     /**
      * Parse arguments.
      *
+     * Supports both legacy (no contexts) and modern (with contexts) parsing.
+     *
      * @param array<string>|null $argv Arguments to parse (null = do not use $_SERVER['argv'])
      * @return ParseResult Immutable parse result
      */
@@ -91,6 +95,23 @@ readonly class ImmutableParser implements ArgvParser
             }
         }
 
+        // If no contexts registered, use legacy parsing
+        if (empty($this->contexts)) {
+            return $this->parseLegacy($argv);
+        }
+
+        // Otherwise use context-aware parsing
+        return $this->parseWithContexts($argv);
+    }
+
+    /**
+     * Legacy parsing (no contexts).
+     *
+     * @param array<string> $argv Arguments to parse
+     * @return ParseResult Parse result
+     */
+    private function parseLegacy(array $argv): ParseResult
+    {
         $values = [];
         $args = [];
         $unknown = [];
@@ -143,6 +164,316 @@ readonly class ImmutableParser implements ArgvParser
             arguments: $args,
             unknown: $unknown
         );
+    }
+
+    /**
+     * Context-aware parsing.
+     *
+     * Parse global options, detect context, then parse context-specific options.
+     *
+     * @param array<string> $argv Arguments to parse
+     * @return ParseResult Parse result with context information
+     */
+    private function parseWithContexts(array $argv): ParseResult
+    {
+        $globalValues = [];
+        $contextValues = [];
+        $args = [];
+        $unknown = [];
+        $activeContext = null;
+
+        // Initialize global option defaults
+        foreach ($this->options as $option) {
+            $dest = $this->getDestination($option);
+            if ($option->default !== null) {
+                $globalValues[$dest] = $option->default;
+            }
+        }
+
+        $rargs = $argv;
+        $largs = [];
+        $contextDetected = false;
+
+        // Phase 1: Parse global options and detect context
+        while (!empty($rargs)) {
+            $arg = array_shift($rargs);
+
+            // Check for end of options marker
+            if ($arg === '--') {
+                $largs = array_merge($largs, $rargs);
+                break;
+            }
+
+            // Check if it looks like an option
+            if ($this->isOption($arg)) {
+                // Process as global option
+                $this->processOption($arg, $rargs, $globalValues, $unknown);
+            } else {
+                // First positional arg might be a context
+                if (!$contextDetected && isset($this->contextMap[$arg])) {
+                    $activeContext = $this->contextMap[$arg];
+                    $contextDetected = true;
+
+                    // Initialize context option defaults
+                    foreach ($activeContext->options as $option) {
+                        $dest = $this->getDestination($option);
+                        if ($option->default !== null) {
+                            $contextValues[$dest] = $option->default;
+                        }
+                    }
+
+                    // Phase 2: Parse context-specific options and arguments
+                    while (!empty($rargs)) {
+                        $arg = array_shift($rargs);
+
+                        // Check for end of options marker
+                        if ($arg === '--') {
+                            $largs = array_merge($largs, $rargs);
+                            break;
+                        }
+
+                        // Check if it looks like an option
+                        if ($this->isOption($arg)) {
+                            // Try context option first, fallback to global
+                            if (!$this->processContextOption($arg, $rargs, $contextValues, $activeContext, $unknown)) {
+                                // Not a context option, try global
+                                $this->processOption($arg, $rargs, $globalValues, $unknown);
+                            }
+                        } else {
+                            // Positional argument for context
+                            $largs[] = $arg;
+                        }
+                    }
+                    break;
+                } else {
+                    // Regular positional argument (no context detected)
+                    $largs[] = $arg;
+                }
+            }
+        }
+
+        $args = $largs;
+
+        // Validate argument count if context is active
+        if ($activeContext !== null) {
+            $argCount = count($args);
+            if (!$activeContext->validateArgumentCount($argCount)) {
+                throw new InvalidArgumentCountException(
+                    $activeContext->name,
+                    $argCount,
+                    $activeContext->minArgs,
+                    $activeContext->maxArgs
+                );
+            }
+        }
+
+        // Filter unknown if ignoreUnknownArgs is set
+        if ($this->config->ignoreUnknownArgs) {
+            $unknown = [];
+        }
+
+        // Build result based on whether context was detected
+        if ($activeContext !== null) {
+            return new ParseResult(
+                options: new OptionValues([]), // Not used in context mode
+                arguments: $args,
+                unknown: $unknown,
+                globalOptions: new OptionValues($globalValues),
+                contextOptions: new OptionValues($contextValues),
+                context: $activeContext->name
+            );
+        } else {
+            // No context detected, return as global options
+            return new ParseResult(
+                options: new OptionValues($globalValues),
+                arguments: $args,
+                unknown: $unknown,
+                globalOptions: new OptionValues($globalValues),
+                contextOptions: new OptionValues([]),
+                context: null
+            );
+        }
+    }
+
+    /**
+     * Process a context-specific option.
+     *
+     * @param string $arg Option argument
+     * @param array &$rargs Remaining arguments (by reference)
+     * @param array &$values Context values (by reference)
+     * @param ContextConfig $context Active context
+     * @param array &$unknown Unknown options (by reference)
+     * @return bool True if option was processed, false if not found in context
+     */
+    private function processContextOption(
+        string $arg,
+        array &$rargs,
+        array &$values,
+        ContextConfig $context,
+        array &$unknown
+    ): bool {
+        // Build context option map
+        $contextOptionMap = [];
+        foreach ($context->options as $option) {
+            if ($option->short !== '') {
+                $contextOptionMap[$option->short] = $option;
+            }
+            if ($option->long !== '') {
+                $contextOptionMap[$option->long] = $option;
+            }
+        }
+
+        // Try to find option in context
+        if (str_starts_with($arg, '--')) {
+            return $this->processLongContextOption($arg, $rargs, $values, $contextOptionMap, $unknown);
+        } else {
+            return $this->processShortContextOption($arg, $rargs, $values, $contextOptionMap, $unknown);
+        }
+    }
+
+    /**
+     * Process long context option.
+     *
+     * @param string $arg Long option
+     * @param array &$rargs Remaining arguments
+     * @param array &$values Current values
+     * @param array<string, OptionConfig> $contextOptionMap Context option map
+     * @param array &$unknown Unknown options
+     * @return bool True if processed
+     */
+    private function processLongContextOption(
+        string $arg,
+        array &$rargs,
+        array &$values,
+        array $contextOptionMap,
+        array &$unknown
+    ): bool {
+        // Handle --option=value format
+        $equals_pos = strpos($arg, '=');
+        if ($equals_pos !== false) {
+            $opt = substr($arg, 0, $equals_pos);
+            $value = substr($arg, $equals_pos + 1);
+        } else {
+            $opt = $arg;
+            $value = null;
+        }
+
+        // Find matching option in context
+        $option = $this->findContextOption($opt, $contextOptionMap);
+        if ($option === null) {
+            return false; // Not found in context
+        }
+
+        // Get value if needed
+        if ($option->action->takesValue()) {
+            if ($value === null) {
+                if (empty($rargs)) {
+                    throw new MissingValueException($opt);
+                }
+                $value = array_shift($rargs);
+            }
+
+            // Type conversion and validation
+            $value = $this->convertAndValidate($option, $value);
+        } else {
+            $value = null;
+        }
+
+        // Execute action
+        $this->executeAction($option, $value, $values);
+
+        return true;
+    }
+
+    /**
+     * Process short context option.
+     *
+     * @param string $arg Short option
+     * @param array &$rargs Remaining arguments
+     * @param array &$values Current values
+     * @param array<string, OptionConfig> $contextOptionMap Context option map
+     * @param array &$unknown Unknown options
+     * @return bool True if processed
+     */
+    private function processShortContextOption(
+        string $arg,
+        array &$rargs,
+        array &$values,
+        array $contextOptionMap,
+        array &$unknown
+    ): bool {
+        // Handle -abc bundling
+        $chars = substr($arg, 1);
+
+        foreach (str_split($chars) as $i => $char) {
+            $opt = '-' . $char;
+
+            // Find option in context
+            if (!isset($contextOptionMap[$opt])) {
+                return false; // Not found in context
+            }
+
+            $option = $contextOptionMap[$opt];
+
+            // Get value if needed
+            if ($option->action->takesValue()) {
+                // Check if value is bundled (-ovalue)
+                if ($i < strlen($chars) - 1) {
+                    $value = substr($chars, $i + 1);
+                } elseif (!empty($rargs)) {
+                    $value = array_shift($rargs);
+                } else {
+                    throw new MissingValueException($opt);
+                }
+
+                // Type conversion and validation
+                $value = $this->convertAndValidate($option, $value);
+
+                // Execute action
+                $this->executeAction($option, $value, $values);
+
+                // Stop processing bundled options after taking a value
+                break;
+            } else {
+                // Flag option, continue with bundling
+                $this->executeAction($option, null, $values);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Find option in context option map.
+     *
+     * @param string $opt Option string
+     * @param array<string, OptionConfig> $contextOptionMap Context option map
+     * @return OptionConfig|null Found option or null
+     */
+    private function findContextOption(string $opt, array $contextOptionMap): ?OptionConfig
+    {
+        // Exact match
+        if (isset($contextOptionMap[$opt])) {
+            return $contextOptionMap[$opt];
+        }
+
+        // Partial match for long options
+        if (str_starts_with($opt, '--')) {
+            $matches = [];
+            foreach (array_keys($contextOptionMap) as $key) {
+                if (str_starts_with($key, $opt)) {
+                    $matches[] = $key;
+                }
+            }
+
+            if (count($matches) === 1) {
+                return $contextOptionMap[$matches[0]];
+            } elseif (count($matches) > 1) {
+                throw new AmbiguousOptionException($opt, $matches);
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/ImmutableParser.php
+++ b/src/ImmutableParser.php
@@ -854,6 +854,56 @@ readonly class ImmutableParser implements ArgvParser
     public function formatHelp(?Modern\Help\HelpFormatter $formatter = null): string
     {
         $formatter ??= $this->helpFormatter ?? Modern\Help\HelpFormatter::create();
-        return $formatter->format($this->config, $this->options, $this->groups);
+        return $formatter->format($this->config, $this->options, $this->groups, $this->contexts);
+    }
+
+    /**
+     * Format help for a specific context.
+     *
+     * @param string $contextName Context name
+     * @param Modern\Help\HelpFormatter|null $formatter Optional formatter
+     * @return string Formatted context help
+     * @throws \InvalidArgumentException If context not found
+     */
+    public function formatContextHelp(string $contextName, ?Modern\Help\HelpFormatter $formatter = null): string
+    {
+        $context = $this->contextMap[$contextName] ?? null;
+        if ($context === null) {
+            throw new \InvalidArgumentException("Unknown context: {$contextName}");
+        }
+
+        $formatter ??= $this->helpFormatter ?? Modern\Help\HelpFormatter::create();
+        return $formatter->formatContextHelp($this->config, $context, $this->options);
+    }
+
+    /**
+     * Get list of available contexts.
+     *
+     * @return array<ContextConfig> Available contexts
+     */
+    public function getContexts(): array
+    {
+        return $this->contexts;
+    }
+
+    /**
+     * Get a specific context by name.
+     *
+     * @param string $name Context name or alias
+     * @return ContextConfig|null Context or null if not found
+     */
+    public function getContext(string $name): ?ContextConfig
+    {
+        return $this->contextMap[$name] ?? null;
+    }
+
+    /**
+     * Check if parser has contexts.
+     *
+     * @return bool True if contexts are registered
+     */
+    public function hasContexts(): bool
+    {
+        return !empty($this->contexts);
     }
 }

--- a/src/ImmutableParser.php
+++ b/src/ImmutableParser.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Horde\Argv;
 
+use InvalidArgumentException;
 use Horde\Argv\Modern\Config\{ParserConfig, OptionConfig, OptionGroupConfig, ContextConfig};
 use Horde\Argv\Modern\Result\{ParseResult, OptionValues};
 use Horde\Argv\Modern\Exception\{
@@ -863,13 +864,13 @@ readonly class ImmutableParser implements ArgvParser
      * @param string $contextName Context name
      * @param Modern\Help\HelpFormatter|null $formatter Optional formatter
      * @return string Formatted context help
-     * @throws \InvalidArgumentException If context not found
+     * @throws InvalidArgumentException If context not found
      */
     public function formatContextHelp(string $contextName, ?Modern\Help\HelpFormatter $formatter = null): string
     {
         $context = $this->contextMap[$contextName] ?? null;
         if ($context === null) {
-            throw new \InvalidArgumentException("Unknown context: {$contextName}");
+            throw new InvalidArgumentException("Unknown context: {$contextName}");
         }
 
         $formatter ??= $this->helpFormatter ?? Modern\Help\HelpFormatter::create();

--- a/src/ImmutableParser.php
+++ b/src/ImmutableParser.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace Horde\Argv;
 
-use Horde\Argv\Modern\Config\{ParserConfig, OptionConfig, OptionGroupConfig};
+use Horde\Argv\Modern\Config\{ParserConfig, OptionConfig, OptionGroupConfig, ContextConfig};
 use Horde\Argv\Modern\Result\{ParseResult, OptionValues};
 use Horde\Argv\Modern\Exception\{
     InvalidOptionException,
@@ -51,23 +51,27 @@ readonly class ImmutableParser implements ArgvParser
 {
     private array $optionMap;      // option string => OptionConfig
     private array $optionsByDest;  // dest name => OptionConfig
+    private array $contextMap;     // context name => ContextConfig
 
     /**
      * Construct immutable parser.
      *
      * @param ParserConfig $config Parser configuration
-     * @param array<OptionConfig> $options Options to parse
+     * @param array<OptionConfig> $options Global options (available in all contexts)
      * @param array<OptionGroupConfig> $groups Option groups (for help formatting)
      * @param mixed $helpFormatter Optional help formatter
+     * @param array<ContextConfig> $contexts Available contexts (subcommands)
      */
     public function __construct(
         private ParserConfig $config,
         private array $options = [],
         private array $groups = [],
         private mixed $helpFormatter = null,
+        private array $contexts = [],
     ) {
         $this->optionMap = $this->buildOptionMap();
         $this->optionsByDest = $this->buildDestMap();
+        $this->contextMap = $this->buildContextMap();
         $this->checkConflicts();
     }
 
@@ -455,6 +459,27 @@ readonly class ImmutableParser implements ArgvParser
     }
 
     /**
+     * Build map of context names to context configs.
+     *
+     * @return array<string, ContextConfig> Context map
+     */
+    private function buildContextMap(): array
+    {
+        $map = [];
+
+        foreach ($this->contexts as $context) {
+            // Map primary name
+            $map[$context->name] = $context;
+            // Map all aliases
+            foreach ($context->aliases as $alias) {
+                $map[$alias] = $context;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
      * Check for conflicting options.
      *
      * @throws ConflictingOptionException If conflicts found
@@ -485,7 +510,8 @@ readonly class ImmutableParser implements ArgvParser
         return Modern\Builder\ParserBuilder::create()
             ->fromConfig($this->config)
             ->setOptions($this->options)
-            ->setGroups($this->groups);
+            ->setGroups($this->groups)
+            ->setContexts($this->contexts);
     }
 
     /**

--- a/src/IndentedHelpFormatter.php
+++ b/src/IndentedHelpFormatter.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,6 +15,7 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
 
 /**
@@ -29,12 +31,18 @@ namespace Horde\Argv;
 class IndentedHelpFormatter extends HelpFormatter
 {
     public function __construct(
-        $indent_increment = 2, $max_help_position = 24, $width = null,
-        $short_first = true, $color = null
-    )
-    {
+        $indent_increment = 2,
+        $max_help_position = 24,
+        $width = null,
+        $short_first = true,
+        $color = null
+    ) {
         parent::__construct(
-            $indent_increment, $max_help_position, $width, $short_first, $color
+            $indent_increment,
+            $max_help_position,
+            $width,
+            $short_first,
+            $color
         );
     }
 
@@ -50,7 +58,9 @@ class IndentedHelpFormatter extends HelpFormatter
     public function formatHeading($heading)
     {
         return $this->highlightHeading(sprintf(
-            '%' . $this->current_indent . "s%s:\n", '', $heading
+            '%' . $this->current_indent . "s%s:\n",
+            '',
+            $heading
         ));
     }
 

--- a/src/Modern/Builder/ContextBuilder.php
+++ b/src/Modern/Builder/ContextBuilder.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2024-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Argv
+ */
+
+namespace Horde\Argv\Modern\Builder;
+
+use Horde\Argv\Modern\Config\ContextConfig;
+use Horde\Argv\Modern\Config\OptionConfig;
+use Horde\Argv\Modern\Config\OptionGroupConfig;
+
+/**
+ * Immutable builder for context configurations.
+ *
+ * Contexts represent subcommands with their own option sets.
+ *
+ * Example:
+ * ```php
+ * $deploy = ContextBuilder::create('deploy')
+ *     ->withDescription('Deploy application')
+ *     ->addOption($forceOption)
+ *     ->requiresArguments(1, 'environment')
+ *     ->build();
+ * ```
+ *
+ * Following Principle #5: Immutable and Explicit
+ * Following Principle #3: Immutable Throughout
+ *
+ * @category Horde
+ * @package  Argv
+ */
+class ContextBuilder
+{
+    /**
+     * Constructor.
+     *
+     * @param string $name Context name
+     * @param string $description Description
+     * @param string $usage Usage string
+     * @param string $help Help text
+     * @param array<string> $aliases Alternative names
+     * @param array<OptionConfig> $options Context-specific options
+     * @param array<OptionGroupConfig> $groups Option groups
+     * @param int $minArgs Minimum arguments
+     * @param int $maxArgs Maximum arguments
+     * @param string $argsDescription Argument description
+     * @param array<ContextConfig> $subContexts Sub-contexts
+     */
+    private function __construct(
+        private string $name,
+        private string $description = '',
+        private string $usage = '',
+        private string $help = '',
+        private array $aliases = [],
+        private array $options = [],
+        private array $groups = [],
+        private int $minArgs = 0,
+        private int $maxArgs = PHP_INT_MAX,
+        private string $argsDescription = '',
+        private array $subContexts = [],
+    ) {
+    }
+
+    /**
+     * Create a new context builder.
+     *
+     * @param string $name Context name (e.g., 'deploy', 'rollback')
+     * @return self New builder instance
+     */
+    public static function create(string $name): self
+    {
+        return new self($name);
+    }
+
+    /**
+     * Set context description.
+     *
+     * @param string $description Description shown in help
+     * @return self New builder with description
+     */
+    public function withDescription(string $description): self
+    {
+        $new = clone $this;
+        $new->description = $description;
+        return $new;
+    }
+
+    /**
+     * Set usage string for this context.
+     *
+     * @param string $usage Usage string (e.g., '%prog deploy [options] <env>')
+     * @return self New builder with usage
+     */
+    public function withUsage(string $usage): self
+    {
+        $new = clone $this;
+        $new->usage = $usage;
+        return $new;
+    }
+
+    /**
+     * Set detailed help text.
+     *
+     * @param string $help Help text
+     * @return self New builder with help
+     */
+    public function withHelp(string $help): self
+    {
+        $new = clone $this;
+        $new->help = $help;
+        return $new;
+    }
+
+    /**
+     * Set context aliases (alternative names).
+     *
+     * @param array<string> $aliases Alternative names (e.g., ['dep', 'depl'])
+     * @return self New builder with aliases
+     */
+    public function withAliases(array $aliases): self
+    {
+        $new = clone $this;
+        $new->aliases = $aliases;
+        return $new;
+    }
+
+    /**
+     * Add an option to this context.
+     *
+     * @param OptionConfig $option Option configuration
+     * @return self New builder with option added
+     */
+    public function addOption(OptionConfig $option): self
+    {
+        $new = clone $this;
+        $new->options = [...$this->options, $option];
+        return $new;
+    }
+
+    /**
+     * Add multiple options to this context.
+     *
+     * @param array<OptionConfig> $options Option configurations
+     * @return self New builder with options added
+     */
+    public function addOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->options = [...$this->options, ...$options];
+        return $new;
+    }
+
+    /**
+     * Add an option group to this context.
+     *
+     * @param OptionGroupConfig $group Option group configuration
+     * @return self New builder with group added
+     */
+    public function addGroup(OptionGroupConfig $group): self
+    {
+        $new = clone $this;
+        $new->groups = [...$this->groups, $group];
+        return $new;
+    }
+
+    /**
+     * Require exact number of arguments after context name.
+     *
+     * @param int $count Required argument count
+     * @param string $description Description of arguments
+     * @return self New builder with argument requirement
+     */
+    public function requiresArguments(int $count, string $description = ''): self
+    {
+        $new = clone $this;
+        $new->minArgs = $count;
+        $new->maxArgs = $count;
+        $new->argsDescription = $description;
+        return $new;
+    }
+
+    /**
+     * Accept a range of arguments after context name.
+     *
+     * @param int $min Minimum argument count
+     * @param int $max Maximum argument count (default: unlimited)
+     * @param string $description Description of arguments
+     * @return self New builder with argument range
+     */
+    public function acceptsArguments(
+        int $min,
+        int $max = PHP_INT_MAX,
+        string $description = ''
+    ): self {
+        $new = clone $this;
+        $new->minArgs = $min;
+        $new->maxArgs = $max;
+        $new->argsDescription = $description;
+        return $new;
+    }
+
+    /**
+     * Require exactly N arguments (alias for requiresArguments).
+     *
+     * @param int $count Required argument count
+     * @return self New builder with exact requirement
+     */
+    public function requiresExactly(int $count): self
+    {
+        return $this->requiresArguments($count);
+    }
+
+    /**
+     * Require at least N arguments.
+     *
+     * @param int $count Minimum argument count
+     * @return self New builder with minimum requirement
+     */
+    public function requiresAtLeast(int $count): self
+    {
+        $new = clone $this;
+        $new->minArgs = $count;
+        $new->maxArgs = PHP_INT_MAX;
+        return $new;
+    }
+
+    /**
+     * Accept at most N arguments.
+     *
+     * @param int $count Maximum argument count
+     * @return self New builder with maximum limit
+     */
+    public function requiresAtMost(int $count): self
+    {
+        $new = clone $this;
+        $new->minArgs = 0;
+        $new->maxArgs = $count;
+        return $new;
+    }
+
+    /**
+     * Add a sub-context (nested command).
+     *
+     * @param ContextConfig $context Sub-context configuration
+     * @return self New builder with sub-context added
+     */
+    public function addContext(ContextConfig $context): self
+    {
+        $new = clone $this;
+        $new->subContexts = [...$this->subContexts, $context];
+        return $new;
+    }
+
+    /**
+     * Build the immutable context configuration.
+     *
+     * @return ContextConfig Immutable context config
+     */
+    public function build(): ContextConfig
+    {
+        return new ContextConfig(
+            name: $this->name,
+            description: $this->description,
+            usage: $this->usage,
+            help: $this->help,
+            aliases: $this->aliases,
+            options: $this->options,
+            groups: $this->groups,
+            minArgs: $this->minArgs,
+            maxArgs: $this->maxArgs,
+            argsDescription: $this->argsDescription,
+            subContexts: $this->subContexts,
+        );
+    }
+}

--- a/src/Modern/Builder/ContextBuilder.php
+++ b/src/Modern/Builder/ContextBuilder.php
@@ -69,8 +69,7 @@ class ContextBuilder
         private int $maxArgs = PHP_INT_MAX,
         private string $argsDescription = '',
         private array $subContexts = [],
-    ) {
-    }
+    ) {}
 
     /**
      * Create a new context builder.

--- a/src/Modern/Builder/OptionBuilder.php
+++ b/src/Modern/Builder/OptionBuilder.php
@@ -53,9 +53,7 @@ class OptionBuilder
     private mixed $validator = null;   // callable|null (Principle #3)
     private mixed $map = null;         // callable|null (Principle #3)
 
-    private function __construct()
-    {
-    }
+    private function __construct() {}
 
     /**
      * Create new builder instance.

--- a/src/Modern/Builder/ParserBuilder.php
+++ b/src/Modern/Builder/ParserBuilder.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Horde\Argv\Modern\Builder;
 
 use Horde\Argv\ImmutableParser;
-use Horde\Argv\Modern\Config\{ParserConfig, OptionConfig, OptionGroupConfig};
+use Horde\Argv\Modern\Config\{ParserConfig, OptionConfig, OptionGroupConfig, ContextConfig};
 use Horde\Argv\Modern\Enum\ConflictHandler;
 
 /**
@@ -44,6 +44,7 @@ class ParserBuilder
     private ParserConfig $config;
     private array $options = [];
     private array $groups = [];
+    private array $contexts = [];
     private mixed $helpFormatter = null;  // HelpFormatter|null
 
     private function __construct()
@@ -233,6 +234,37 @@ class ParserBuilder
     }
 
     /**
+     * Add a context (subcommand).
+     *
+     * Contexts provide command-specific option sets that don't conflict.
+     * Example: git commit --amend vs git push --force
+     *
+     * @param ContextConfig $context Context to add
+     * @return self New builder instance
+     */
+    public function addContext(ContextConfig $context): self
+    {
+        $new = clone $this;
+        $new->contexts[] = $context;
+        return $new;
+    }
+
+    /**
+     * Add multiple contexts.
+     *
+     * @param array<ContextConfig> $contexts Contexts to add
+     * @return self New builder instance
+     */
+    public function addContexts(array $contexts): self
+    {
+        $new = clone $this;
+        foreach ($contexts as $context) {
+            $new->contexts[] = $context;
+        }
+        return $new;
+    }
+
+    /**
      * Set help formatter (optional, avoids circular dependencies).
      *
      * Note: Formatter can also be provided at parse time to avoid
@@ -259,7 +291,8 @@ class ParserBuilder
             $this->config,
             $this->options,
             $this->groups,
-            $this->helpFormatter
+            $this->helpFormatter,
+            $this->contexts
         );
     }
 
@@ -301,6 +334,19 @@ class ParserBuilder
     {
         $new = clone $this;
         $new->groups = $groups;
+        return $new;
+    }
+
+    /**
+     * Set contexts (internal use for use-and-amend pattern).
+     *
+     * @param array<ContextConfig> $contexts Contexts array
+     * @return self New builder instance
+     */
+    public function setContexts(array $contexts): self
+    {
+        $new = clone $this;
+        $new->contexts = $contexts;
         return $new;
     }
 }

--- a/src/Modern/Config/ContextConfig.php
+++ b/src/Modern/Config/ContextConfig.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2024-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Argv
+ */
+
+namespace Horde\Argv\Modern\Config;
+
+/**
+ * Immutable context configuration.
+ *
+ * Contexts represent subcommands or command modes that have their own
+ * set of options. Options in different contexts don't conflict with each other.
+ *
+ * Example: git commit --amend vs git push --force
+ *          These --force options are different and context-specific.
+ *
+ * Following Principle #7: Immutable Throughout
+ *
+ * @category Horde
+ * @package  Argv
+ */
+readonly class ContextConfig
+{
+    /**
+     * Constructor.
+     *
+     * @param string $name Context name (e.g., 'deploy', 'rollback')
+     * @param string $description Description shown in help
+     * @param string $usage Usage string for this context
+     * @param string $help Detailed help text
+     * @param array<string> $aliases Alternative names for this context
+     * @param array<OptionConfig> $options Options specific to this context
+     * @param array<OptionGroupConfig> $groups Option groups for this context
+     * @param int $minArgs Minimum required arguments after context name
+     * @param int $maxArgs Maximum allowed arguments after context name
+     * @param string $argsDescription Description of expected arguments
+     * @param array<ContextConfig> $subContexts Nested sub-contexts
+     */
+    public function __construct(
+        public string $name,
+        public string $description = '',
+        public string $usage = '',
+        public string $help = '',
+        public array $aliases = [],
+        public array $options = [],
+        public array $groups = [],
+        public int $minArgs = 0,
+        public int $maxArgs = PHP_INT_MAX,
+        public string $argsDescription = '',
+        public array $subContexts = [],
+    ) {
+        $this->validate();
+    }
+
+    /**
+     * Validate context configuration.
+     *
+     * @throws \InvalidArgumentException If configuration is invalid
+     */
+    private function validate(): void
+    {
+        if ($this->name === '') {
+            throw new \InvalidArgumentException('Context name cannot be empty');
+        }
+
+        if ($this->minArgs < 0) {
+            throw new \InvalidArgumentException('minArgs must be >= 0');
+        }
+
+        if ($this->maxArgs < $this->minArgs) {
+            throw new \InvalidArgumentException('maxArgs must be >= minArgs');
+        }
+
+        // Validate all options
+        foreach ($this->options as $option) {
+            if (!$option instanceof OptionConfig) {
+                throw new \InvalidArgumentException('All options must be OptionConfig instances');
+            }
+        }
+
+        // Validate all groups
+        foreach ($this->groups as $group) {
+            if (!$group instanceof OptionGroupConfig) {
+                throw new \InvalidArgumentException('All groups must be OptionGroupConfig instances');
+            }
+        }
+
+        // Validate all sub-contexts
+        foreach ($this->subContexts as $subContext) {
+            if (!$subContext instanceof ContextConfig) {
+                throw new \InvalidArgumentException('All sub-contexts must be ContextConfig instances');
+            }
+        }
+
+        // Validate aliases don't conflict with name
+        if (in_array($this->name, $this->aliases, true)) {
+            throw new \InvalidArgumentException('Context name cannot be in aliases list');
+        }
+    }
+
+    /**
+     * Check if a given name matches this context.
+     *
+     * @param string $name Name to check
+     * @return bool True if name matches context name or any alias
+     */
+    public function matches(string $name): bool
+    {
+        return $this->name === $name || in_array($name, $this->aliases, true);
+    }
+
+    /**
+     * Get all valid names for this context.
+     *
+     * @return array<string> Context name plus all aliases
+     */
+    public function getAllNames(): array
+    {
+        return [$this->name, ...$this->aliases];
+    }
+
+    /**
+     * Find a sub-context by name.
+     *
+     * @param string $name Sub-context name
+     * @return ContextConfig|null Sub-context or null if not found
+     */
+    public function findSubContext(string $name): ?ContextConfig
+    {
+        foreach ($this->subContexts as $subContext) {
+            if ($subContext->matches($name)) {
+                return $subContext;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Check if this context has sub-contexts.
+     *
+     * @return bool True if sub-contexts exist
+     */
+    public function hasSubContexts(): bool
+    {
+        return count($this->subContexts) > 0;
+    }
+
+    /**
+     * Validate argument count against context requirements.
+     *
+     * @param int $count Actual argument count
+     * @return bool True if count is valid
+     */
+    public function validateArgumentCount(int $count): bool
+    {
+        return $count >= $this->minArgs && $count <= $this->maxArgs;
+    }
+
+    /**
+     * Get argument count error message.
+     *
+     * @param int $actualCount Actual argument count
+     * @return string Error message
+     */
+    public function getArgumentCountError(int $actualCount): string
+    {
+        if ($this->minArgs === $this->maxArgs) {
+            return sprintf(
+                'Context "%s" requires exactly %d argument%s, got %d',
+                $this->name,
+                $this->minArgs,
+                $this->minArgs === 1 ? '' : 's',
+                $actualCount
+            );
+        }
+
+        if ($actualCount < $this->minArgs) {
+            return sprintf(
+                'Context "%s" requires at least %d argument%s, got %d',
+                $this->name,
+                $this->minArgs,
+                $this->minArgs === 1 ? '' : 's',
+                $actualCount
+            );
+        }
+
+        return sprintf(
+            'Context "%s" accepts at most %d argument%s, got %d',
+            $this->name,
+            $this->maxArgs,
+            $this->maxArgs === 1 ? '' : 's',
+            $actualCount
+        );
+    }
+}

--- a/src/Modern/Config/ContextConfig.php
+++ b/src/Modern/Config/ContextConfig.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace Horde\Argv\Modern\Config;
 
+use InvalidArgumentException;
+
 /**
  * Immutable context configuration.
  *
@@ -66,46 +68,46 @@ readonly class ContextConfig
     /**
      * Validate context configuration.
      *
-     * @throws \InvalidArgumentException If configuration is invalid
+     * @throws InvalidArgumentException If configuration is invalid
      */
     private function validate(): void
     {
         if ($this->name === '') {
-            throw new \InvalidArgumentException('Context name cannot be empty');
+            throw new InvalidArgumentException('Context name cannot be empty');
         }
 
         if ($this->minArgs < 0) {
-            throw new \InvalidArgumentException('minArgs must be >= 0');
+            throw new InvalidArgumentException('minArgs must be >= 0');
         }
 
         if ($this->maxArgs < $this->minArgs) {
-            throw new \InvalidArgumentException('maxArgs must be >= minArgs');
+            throw new InvalidArgumentException('maxArgs must be >= minArgs');
         }
 
         // Validate all options
         foreach ($this->options as $option) {
             if (!$option instanceof OptionConfig) {
-                throw new \InvalidArgumentException('All options must be OptionConfig instances');
+                throw new InvalidArgumentException('All options must be OptionConfig instances');
             }
         }
 
         // Validate all groups
         foreach ($this->groups as $group) {
             if (!$group instanceof OptionGroupConfig) {
-                throw new \InvalidArgumentException('All groups must be OptionGroupConfig instances');
+                throw new InvalidArgumentException('All groups must be OptionGroupConfig instances');
             }
         }
 
         // Validate all sub-contexts
         foreach ($this->subContexts as $subContext) {
             if (!$subContext instanceof ContextConfig) {
-                throw new \InvalidArgumentException('All sub-contexts must be ContextConfig instances');
+                throw new InvalidArgumentException('All sub-contexts must be ContextConfig instances');
             }
         }
 
         // Validate aliases don't conflict with name
         if (in_array($this->name, $this->aliases, true)) {
-            throw new \InvalidArgumentException('Context name cannot be in aliases list');
+            throw new InvalidArgumentException('Context name cannot be in aliases list');
         }
     }
 

--- a/src/Modern/Config/OptionGroupConfig.php
+++ b/src/Modern/Config/OptionGroupConfig.php
@@ -39,6 +39,5 @@ readonly class OptionGroupConfig
         public string $title,
         public string $description = '',
         public array $options = [],
-    ) {
-    }
+    ) {}
 }

--- a/src/Modern/Config/ParserConfig.php
+++ b/src/Modern/Config/ParserConfig.php
@@ -54,8 +54,7 @@ readonly class ParserConfig
         public bool $ignoreUnknownArgs = false,
         public bool $addHelpOption = true,
         public ConflictHandler $conflictHandler = ConflictHandler::Error,
-    ) {
-    }
+    ) {}
 
     /**
      * Create a modified copy with one property changed.

--- a/src/Modern/Enum/OptionType.php
+++ b/src/Modern/Enum/OptionType.php
@@ -44,7 +44,7 @@ enum OptionType: string
     public function validate(mixed $value): bool
     {
         return match ($this) {
-            self::Int => is_numeric($value) && (string)(int)$value === (string)$value,
+            self::Int => is_numeric($value) && (string) (int) $value === (string) $value,
             self::Float => is_numeric($value),
             self::String => true,  // All values can be strings
         };
@@ -75,9 +75,9 @@ enum OptionType: string
         }
 
         return match ($this) {
-            self::Int => (int)$value,
-            self::Float => (float)$value,
-            self::String => (string)$value,
+            self::Int => (int) $value,
+            self::Float => (float) $value,
+            self::String => (string) $value,
         };
     }
 

--- a/src/Modern/Exception/AmbiguousOptionException.php
+++ b/src/Modern/Exception/AmbiguousOptionException.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Horde\Argv\Modern\Exception;
 
 use Throwable;
+use Exception;
 
 /**
  * Ambiguous partial option match exception.
@@ -27,7 +28,7 @@ use Throwable;
  * @category Horde
  * @package  Argv
  */
-class AmbiguousOptionException extends \Exception
+class AmbiguousOptionException extends Exception
 {
     /**
      * Constructor.

--- a/src/Modern/Exception/ConflictingOptionException.php
+++ b/src/Modern/Exception/ConflictingOptionException.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Horde\Argv\Modern\Exception;
 
 use Throwable;
+use Exception;
 
 /**
  * Conflicting options exception.
@@ -27,7 +28,7 @@ use Throwable;
  * @category Horde
  * @package  Argv
  */
-class ConflictingOptionException extends \Exception
+class ConflictingOptionException extends Exception
 {
     /**
      * Constructor.

--- a/src/Modern/Exception/InvalidArgumentCountException.php
+++ b/src/Modern/Exception/InvalidArgumentCountException.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace Horde\Argv\Modern\Exception;
 
+use Exception;
+
 /**
  * Exception for invalid argument counts in contexts.
  *
@@ -24,7 +26,7 @@ namespace Horde\Argv\Modern\Exception;
  * @category Horde
  * @package  Argv
  */
-class InvalidArgumentCountException extends \Exception
+class InvalidArgumentCountException extends Exception
 {
     /**
      * Constructor.

--- a/src/Modern/Exception/InvalidArgumentCountException.php
+++ b/src/Modern/Exception/InvalidArgumentCountException.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2024-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Argv
+ */
+
+namespace Horde\Argv\Modern\Exception;
+
+/**
+ * Exception for invalid argument counts in contexts.
+ *
+ * Thrown when a context receives wrong number of positional arguments.
+ *
+ * @category Horde
+ * @package  Argv
+ */
+class InvalidArgumentCountException extends \Exception
+{
+    /**
+     * Constructor.
+     *
+     * @param string $contextName Context name
+     * @param int $actualCount Actual argument count
+     * @param int $minArgs Minimum required arguments
+     * @param int $maxArgs Maximum allowed arguments
+     */
+    public function __construct(
+        public readonly string $contextName,
+        public readonly int $actualCount,
+        public readonly int $minArgs,
+        public readonly int $maxArgs
+    ) {
+        if ($minArgs === $maxArgs) {
+            $message = sprintf(
+                "Context '%s' requires exactly %d argument%s, got %d",
+                $contextName,
+                $minArgs,
+                $minArgs === 1 ? '' : 's',
+                $actualCount
+            );
+        } elseif ($actualCount < $minArgs) {
+            $message = sprintf(
+                "Context '%s' requires at least %d argument%s, got %d",
+                $contextName,
+                $minArgs,
+                $minArgs === 1 ? '' : 's',
+                $actualCount
+            );
+        } else {
+            $message = sprintf(
+                "Context '%s' accepts at most %d argument%s, got %d",
+                $contextName,
+                $maxArgs,
+                $maxArgs === 1 ? '' : 's',
+                $actualCount
+            );
+        }
+
+        parent::__construct($message);
+    }
+}

--- a/src/Modern/Exception/InvalidOptionException.php
+++ b/src/Modern/Exception/InvalidOptionException.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Horde\Argv\Modern\Exception;
 
 use Throwable;
+use Exception;
 
 /**
  * Invalid option configuration exception.
@@ -27,7 +28,7 @@ use Throwable;
  * @category Horde
  * @package  Argv
  */
-class InvalidOptionException extends \Exception
+class InvalidOptionException extends Exception
 {
     /**
      * Constructor.

--- a/src/Modern/Exception/MissingValueException.php
+++ b/src/Modern/Exception/MissingValueException.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Horde\Argv\Modern\Exception;
 
 use Throwable;
+use Exception;
 
 /**
  * Required value missing exception.
@@ -27,7 +28,7 @@ use Throwable;
  * @category Horde
  * @package  Argv
  */
-class MissingValueException extends \Exception
+class MissingValueException extends Exception
 {
     /**
      * Constructor.

--- a/src/Modern/Exception/UnknownContextException.php
+++ b/src/Modern/Exception/UnknownContextException.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2024-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Argv
+ */
+
+namespace Horde\Argv\Modern\Exception;
+
+/**
+ * Exception for unknown context (subcommand) names.
+ *
+ * Thrown when a positional argument doesn't match any registered context.
+ *
+ * @category Horde
+ * @package  Argv
+ */
+class UnknownContextException extends \Exception
+{
+    /**
+     * Constructor.
+     *
+     * @param string $contextName Unknown context name
+     * @param array<string> $availableContexts Available context names
+     */
+    public function __construct(
+        public readonly string $contextName,
+        public readonly array $availableContexts = []
+    ) {
+        $message = "Unknown context: '{$contextName}'";
+
+        if (count($availableContexts) > 0) {
+            $message .= "\nAvailable contexts: " . implode(', ', $availableContexts);
+        }
+
+        parent::__construct($message);
+    }
+}

--- a/src/Modern/Exception/UnknownContextException.php
+++ b/src/Modern/Exception/UnknownContextException.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace Horde\Argv\Modern\Exception;
 
+use Exception;
+
 /**
  * Exception for unknown context (subcommand) names.
  *
@@ -24,7 +26,7 @@ namespace Horde\Argv\Modern\Exception;
  * @category Horde
  * @package  Argv
  */
-class UnknownContextException extends \Exception
+class UnknownContextException extends Exception
 {
     /**
      * Constructor.

--- a/src/Modern/Exception/ValueValidationException.php
+++ b/src/Modern/Exception/ValueValidationException.php
@@ -18,6 +18,7 @@ namespace Horde\Argv\Modern\Exception;
 
 use Horde\Argv\Modern\Enum\OptionType;
 use Throwable;
+use Exception;
 
 /**
  * Value validation failed exception.
@@ -28,7 +29,7 @@ use Throwable;
  * @category Horde
  * @package  Argv
  */
-class ValueValidationException extends \Exception
+class ValueValidationException extends Exception
 {
     /**
      * Constructor.

--- a/src/Modern/Help/HelpFormatter.php
+++ b/src/Modern/Help/HelpFormatter.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace Horde\Argv\Modern\Help;
 
-use Horde\Argv\Modern\Config\{ParserConfig, OptionConfig, OptionGroupConfig};
+use Horde\Argv\Modern\Config\{ParserConfig, OptionConfig, OptionGroupConfig, ContextConfig};
 
 /**
  * Immutable help formatter for Modern API.
@@ -123,12 +123,14 @@ readonly class HelpFormatter
      * @param ParserConfig $config Parser configuration
      * @param array<OptionConfig> $options Options to format
      * @param array<OptionGroupConfig> $groups Option groups
+     * @param array<ContextConfig> $contexts Available contexts
      * @return string Formatted help text
      */
     public function format(
         ParserConfig $config,
         array $options = [],
-        array $groups = []
+        array $groups = [],
+        array $contexts = []
     ): string {
         $parts = [];
 
@@ -140,6 +142,11 @@ readonly class HelpFormatter
         // Description
         if ($config->description !== '' && $config->description !== null) {
             $parts[] = $this->formatDescription($config->description);
+        }
+
+        // Contexts (if any)
+        if (!empty($contexts)) {
+            $parts[] = $this->formatContexts($contexts);
         }
 
         // Options
@@ -164,11 +171,12 @@ readonly class HelpFormatter
      * Format usage line.
      *
      * @param string $usage Usage template
-     * @param string $prog Program name
+     * @param string|null $prog Program name
      * @return string Formatted usage
      */
-    private function formatUsage(string $usage, string $prog): string
+    private function formatUsage(string $usage, ?string $prog): string
     {
+        $prog ??= 'program';
         $usage = str_replace('%prog', $prog, $usage);
         return "Usage: {$usage}\n";
     }
@@ -419,5 +427,154 @@ readonly class HelpFormatter
         }
 
         return $width;
+    }
+
+    /**
+     * Format contexts section.
+     *
+     * @param array<ContextConfig> $contexts Contexts to format
+     * @return string Formatted contexts section
+     */
+    private function formatContexts(array $contexts): string
+    {
+        $lines = ["Commands:"];
+
+        foreach ($contexts as $context) {
+            $lines[] = $this->formatContext($context);
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * Format a single context.
+     *
+     * @param ContextConfig $context Context to format
+     * @return string Formatted context line
+     */
+    private function formatContext(ContextConfig $context): string
+    {
+        $indent = str_repeat(' ', $this->indent);
+
+        // Format context name with aliases
+        $names = $context->name;
+        if (!empty($context->aliases)) {
+            $names .= ' (' . implode(', ', $context->aliases) . ')';
+        }
+
+        // Pad to max help position
+        $nameWidth = $this->maxHelpPosition - $this->indent;
+        $namePart = str_pad($names, $nameWidth);
+
+        // Description
+        $desc = $context->description;
+        if ($desc === '') {
+            return $indent . $names;
+        }
+
+        // Wrap description if needed
+        $descWidth = $this->getWidth() - $this->maxHelpPosition;
+        if (strlen($desc) > $descWidth) {
+            $desc = wordwrap($desc, $descWidth, "\n" . str_repeat(' ', $this->maxHelpPosition));
+        }
+
+        return $indent . $namePart . $desc;
+    }
+
+    /**
+     * Format help for a specific context.
+     *
+     * Generates help text for a single context, showing context-specific options.
+     *
+     * @param ParserConfig $config Parser configuration
+     * @param ContextConfig $context Context to format
+     * @param array<OptionConfig> $globalOptions Global options
+     * @return string Formatted context help
+     */
+    public function formatContextHelp(
+        ParserConfig $config,
+        ContextConfig $context,
+        array $globalOptions = []
+    ): string {
+        $parts = [];
+
+        // Usage (context-specific if available)
+        $usage = $context->usage !== '' ? $context->usage : $config->usage;
+        if ($usage !== '' && $usage !== null) {
+            $prog = $config->prog ?? 'program';
+            $usage = str_replace('%prog', $prog . ' ' . $context->name, $usage);
+            $parts[] = "Usage: {$usage}\n";
+        }
+
+        // Context description
+        if ($context->description !== '') {
+            $parts[] = $this->formatDescription($context->description);
+        }
+
+        // Context help (detailed)
+        if ($context->help !== '') {
+            $parts[] = $this->wrapText($context->help) . "\n";
+        }
+
+        // Context-specific options
+        if (!empty($context->options)) {
+            $parts[] = "Context Options:";
+            $parts[] = $this->formatOptions($context->options);
+        }
+
+        // Global options (if any)
+        if (!empty($globalOptions)) {
+            $parts[] = "Global Options:";
+            $parts[] = $this->formatOptions($globalOptions);
+        }
+
+        // Argument requirements
+        if ($context->minArgs > 0 || $context->maxArgs < PHP_INT_MAX) {
+            $argInfo = $this->formatArgumentRequirements($context);
+            if ($argInfo !== '') {
+                $parts[] = $argInfo;
+            }
+        }
+
+        return implode("\n", array_filter($parts)) . "\n";
+    }
+
+    /**
+     * Format argument requirements for a context.
+     *
+     * @param ContextConfig $context Context
+     * @return string Formatted argument requirements
+     */
+    private function formatArgumentRequirements(ContextConfig $context): string
+    {
+        $parts = ["Arguments:"];
+        $indent = str_repeat(' ', $this->indent);
+
+        $desc = $context->argsDescription !== '' ? ': ' . $context->argsDescription : '';
+
+        if ($context->minArgs === $context->maxArgs) {
+            $parts[] = $indent . sprintf(
+                "Requires exactly %d argument%s%s",
+                $context->minArgs,
+                $context->minArgs === 1 ? '' : 's',
+                $desc
+            );
+        } elseif ($context->maxArgs === PHP_INT_MAX) {
+            $parts[] = $indent . sprintf(
+                "Requires at least %d argument%s%s",
+                $context->minArgs,
+                $context->minArgs === 1 ? '' : 's',
+                $desc
+            );
+        } else {
+            $parts[] = $indent . sprintf(
+                "Accepts %d-%d arguments%s",
+                $context->minArgs,
+                $context->maxArgs,
+                $desc
+            );
+        }
+
+        return implode("\n", $parts);
     }
 }

--- a/src/Modern/Help/HelpFormatter.php
+++ b/src/Modern/Help/HelpFormatter.php
@@ -1,0 +1,423 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2024-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Argv
+ */
+
+namespace Horde\Argv\Modern\Help;
+
+use Horde\Argv\Modern\Config\{ParserConfig, OptionConfig, OptionGroupConfig};
+
+/**
+ * Immutable help formatter for Modern API.
+ *
+ * Following Principle #5: Modern API is Immutable and Explicit
+ * Formatter is configured once and produces help text on demand.
+ *
+ * Usage:
+ *   $formatter = HelpFormatter::create()
+ *       ->withWidth(80)
+ *       ->withIndent(2)
+ *       ->build();
+ *
+ *   $help = $formatter->format($parserConfig, $options, $groups);
+ *
+ * @category Horde
+ * @package  Argv
+ */
+readonly class HelpFormatter
+{
+    /**
+     * Construct formatter.
+     *
+     * @param int $width Terminal width (0 = auto-detect)
+     * @param int $indent Indentation increment
+     * @param int $maxHelpPosition Maximum position before wrapping help text
+     * @param bool $shortFirst Show short option first in listings
+     */
+    public function __construct(
+        private int $width = 80,
+        private int $indent = 2,
+        private int $maxHelpPosition = 24,
+        private bool $shortFirst = true,
+    ) {
+    }
+
+    /**
+     * Create formatter with default settings.
+     *
+     * @return self
+     */
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    /**
+     * Set terminal width.
+     *
+     * @param int $width Width in characters (0 = auto-detect)
+     * @return self New formatter instance
+     */
+    public function withWidth(int $width): self
+    {
+        return new self($width, $this->indent, $this->maxHelpPosition, $this->shortFirst);
+    }
+
+    /**
+     * Set indentation increment.
+     *
+     * @param int $indent Spaces per indent level
+     * @return self New formatter instance
+     */
+    public function withIndent(int $indent): self
+    {
+        return new self($this->width, $indent, $this->maxHelpPosition, $this->shortFirst);
+    }
+
+    /**
+     * Set maximum help text position.
+     *
+     * @param int $position Column position before wrapping
+     * @return self New formatter instance
+     */
+    public function withMaxHelpPosition(int $position): self
+    {
+        return new self($this->width, $this->indent, $position, $this->shortFirst);
+    }
+
+    /**
+     * Set option ordering.
+     *
+     * @param bool $shortFirst True to show short option first
+     * @return self New formatter instance
+     */
+    public function withShortFirst(bool $shortFirst = true): self
+    {
+        return new self($this->width, $this->indent, $this->maxHelpPosition, $shortFirst);
+    }
+
+    /**
+     * Build complete formatter (for consistency with builder pattern).
+     *
+     * @return self
+     */
+    public function build(): self
+    {
+        return $this;
+    }
+
+    /**
+     * Format complete help text.
+     *
+     * @param ParserConfig $config Parser configuration
+     * @param array<OptionConfig> $options Options to format
+     * @param array<OptionGroupConfig> $groups Option groups
+     * @return string Formatted help text
+     */
+    public function format(
+        ParserConfig $config,
+        array $options = [],
+        array $groups = []
+    ): string {
+        $parts = [];
+
+        // Usage
+        if ($config->usage !== '' && $config->usage !== null) {
+            $parts[] = $this->formatUsage($config->usage, $config->prog);
+        }
+
+        // Description
+        if ($config->description !== '' && $config->description !== null) {
+            $parts[] = $this->formatDescription($config->description);
+        }
+
+        // Options
+        if (!empty($options)) {
+            $parts[] = $this->formatOptions($options);
+        }
+
+        // Groups
+        foreach ($groups as $group) {
+            $parts[] = $this->formatGroup($group);
+        }
+
+        // Epilog
+        if ($config->epilog !== '' && $config->epilog !== null) {
+            $parts[] = $this->formatEpilog($config->epilog);
+        }
+
+        return implode("\n", array_filter($parts)) . "\n";
+    }
+
+    /**
+     * Format usage line.
+     *
+     * @param string $usage Usage template
+     * @param string $prog Program name
+     * @return string Formatted usage
+     */
+    private function formatUsage(string $usage, string $prog): string
+    {
+        $usage = str_replace('%prog', $prog, $usage);
+        return "Usage: {$usage}\n";
+    }
+
+    /**
+     * Format description text.
+     *
+     * @param string $description Description text
+     * @return string Formatted description
+     */
+    private function formatDescription(string $description): string
+    {
+        return $this->wrapText($description) . "\n";
+    }
+
+    /**
+     * Format epilog text.
+     *
+     * @param string $epilog Epilog text
+     * @return string Formatted epilog
+     */
+    private function formatEpilog(string $epilog): string
+    {
+        return $this->wrapText($epilog);
+    }
+
+    /**
+     * Format options section.
+     *
+     * @param array<OptionConfig> $options Options to format
+     * @return string Formatted options
+     */
+    private function formatOptions(array $options): string
+    {
+        $lines = ["Options:"];
+
+        foreach ($options as $option) {
+            $lines[] = $this->formatOption($option);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Format option group.
+     *
+     * @param OptionGroupConfig $group Group to format
+     * @return string Formatted group
+     */
+    private function formatGroup(OptionGroupConfig $group): string
+    {
+        $lines = [$group->title . ':'];
+
+        if ($group->description !== '') {
+            $lines[] = $this->indent($this->wrapText($group->description));
+        }
+
+        foreach ($group->options as $option) {
+            $lines[] = $this->formatOption($option);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Format single option.
+     *
+     * @param OptionConfig $option Option to format
+     * @return string Formatted option
+     */
+    private function formatOption(OptionConfig $option): string
+    {
+        $opts = [];
+
+        if ($this->shortFirst) {
+            if ($option->short !== '') {
+                $opts[] = $this->formatOptionString($option, true);
+            }
+            if ($option->long !== '') {
+                $opts[] = $this->formatOptionString($option, false);
+            }
+        } else {
+            if ($option->long !== '') {
+                $opts[] = $this->formatOptionString($option, false);
+            }
+            if ($option->short !== '') {
+                $opts[] = $this->formatOptionString($option, true);
+            }
+        }
+
+        $optStr = implode(', ', $opts);
+        $help = $option->help ?? '';
+
+        // Add default value to help text if present
+        if ($option->default !== null && !$option->action->isBoolean()) {
+            $defaultStr = is_array($option->default)
+                ? '[' . implode(', ', $option->default) . ']'
+                : (string)$option->default;
+            $help .= " (default: {$defaultStr})";
+        }
+
+        // Add choices to help text if present
+        if (!empty($option->choices)) {
+            $choiceStr = implode(', ', array_map(fn($c) => "'{$c}'", $option->choices));
+            $help .= " (choices: {$choiceStr})";
+        }
+
+        return $this->formatOptionLine($optStr, $help);
+    }
+
+    /**
+     * Format option string with argument placeholder.
+     *
+     * @param OptionConfig $option Option configuration
+     * @param bool $short True for short format, false for long
+     * @return string Formatted option string
+     */
+    private function formatOptionString(OptionConfig $option, bool $short): string
+    {
+        $opt = $short ? $option->short : $option->long;
+
+        if (!$option->action->takesValue()) {
+            return $opt;
+        }
+
+        $metavar = $option->metavar ?? strtoupper($option->getDestination());
+
+        if ($short) {
+            return "{$opt} {$metavar}";
+        } else {
+            return "{$opt}={$metavar}";
+        }
+    }
+
+    /**
+     * Format option line with help text.
+     *
+     * @param string $optStr Option string
+     * @param string $help Help text
+     * @return string Formatted line
+     */
+    private function formatOptionLine(string $optStr, string $help): string
+    {
+        $indent = str_repeat(' ', $this->indent);
+        $optStr = $indent . $optStr;
+
+        if (strlen($optStr) < $this->maxHelpPosition && $help !== '') {
+            // Help on same line
+            $padding = str_repeat(' ', $this->maxHelpPosition - strlen($optStr));
+            $helpIndent = str_repeat(' ', $this->maxHelpPosition);
+            $wrappedHelp = $this->wrapText(
+                $help,
+                $this->width - $this->maxHelpPosition,
+                $helpIndent
+            );
+            return $optStr . $padding . $wrappedHelp;
+        } elseif ($help !== '') {
+            // Help on next line
+            $helpIndent = str_repeat(' ', $this->maxHelpPosition);
+            $wrappedHelp = $this->wrapText(
+                $help,
+                $this->width - $this->maxHelpPosition,
+                $helpIndent
+            );
+            return $optStr . "\n" . $helpIndent . $wrappedHelp;
+        } else {
+            return $optStr;
+        }
+    }
+
+    /**
+     * Wrap text to terminal width.
+     *
+     * @param string $text Text to wrap
+     * @param int|null $width Width (null = use default)
+     * @param string $indent Indentation for wrapped lines
+     * @return string Wrapped text
+     */
+    private function wrapText(string $text, ?int $width = null, string $indent = ''): string
+    {
+        $width ??= $this->width;
+
+        if ($width <= 0 || strlen($text) <= $width) {
+            return $text;
+        }
+
+        $words = explode(' ', $text);
+        $lines = [];
+        $currentLine = '';
+
+        foreach ($words as $word) {
+            $testLine = $currentLine === '' ? $word : $currentLine . ' ' . $word;
+            $lineLength = strlen($indent) + strlen($testLine);
+
+            if ($lineLength > $width && $currentLine !== '') {
+                $lines[] = $currentLine;
+                $currentLine = $word;
+            } else {
+                $currentLine = $testLine;
+            }
+        }
+
+        if ($currentLine !== '') {
+            $lines[] = $currentLine;
+        }
+
+        if ($indent === '') {
+            return implode("\n", $lines);
+        }
+
+        return implode("\n" . $indent, $lines);
+    }
+
+    /**
+     * Indent text.
+     *
+     * @param string $text Text to indent
+     * @param int $level Indent level (multiplied by indent)
+     * @return string Indented text
+     */
+    private function indent(string $text, int $level = 1): string
+    {
+        $indent = str_repeat(' ', $this->indent * $level);
+        $lines = explode("\n", $text);
+        return implode("\n", array_map(fn($l) => $indent . $l, $lines));
+    }
+
+    /**
+     * Get terminal width.
+     *
+     * @return int Width in characters
+     */
+    public function getWidth(): int
+    {
+        if ($this->width > 0) {
+            return $this->width;
+        }
+
+        // Auto-detect terminal width
+        $width = 80; // Default fallback
+
+        if (function_exists('exec')) {
+            $output = [];
+            @exec('tput cols 2>/dev/null', $output);
+            if (isset($output[0]) && is_numeric($output[0])) {
+                $width = (int)$output[0];
+            }
+        }
+
+        return $width;
+    }
+}

--- a/src/Modern/Help/HelpFormatter.php
+++ b/src/Modern/Help/HelpFormatter.php
@@ -50,8 +50,7 @@ readonly class HelpFormatter
         private int $indent = 2,
         private int $maxHelpPosition = 24,
         private bool $shortFirst = true,
-    ) {
-    }
+    ) {}
 
     /**
      * Create formatter with default settings.
@@ -274,7 +273,7 @@ readonly class HelpFormatter
         if ($option->default !== null && !$option->action->isBoolean()) {
             $defaultStr = is_array($option->default)
                 ? '[' . implode(', ', $option->default) . ']'
-                : (string)$option->default;
+                : (string) $option->default;
             $help .= " (default: {$defaultStr})";
         }
 
@@ -422,7 +421,7 @@ readonly class HelpFormatter
             $output = [];
             @exec('tput cols 2>/dev/null', $output);
             if (isset($output[0]) && is_numeric($output[0])) {
-                $width = (int)$output[0];
+                $width = (int) $output[0];
             }
         }
 

--- a/src/Modern/Result/OptionValues.php
+++ b/src/Modern/Result/OptionValues.php
@@ -36,8 +36,7 @@ readonly class OptionValues
      */
     public function __construct(
         private array $values = [],
-    ) {
-    }
+    ) {}
 
     /**
      * Get option value with optional default.

--- a/src/Modern/Result/ParseResult.php
+++ b/src/Modern/Result/ParseResult.php
@@ -25,6 +25,14 @@ namespace Horde\Argv\Modern\Result;
  *
  * Following Principle #7: Immutable Throughout
  *
+ * Supports contextual option groups (subcommands):
+ * - globalOptions: Options available across all contexts
+ * - contextOptions: Options specific to activated context
+ * - context: Name of activated context (null if no context)
+ * - arguments: Positional arguments (after context name if context active)
+ *
+ * Backward compatible: When no contexts used, all options in $options property.
+ *
  * @category Horde
  * @package  Argv
  */
@@ -33,14 +41,20 @@ readonly class ParseResult
     /**
      * Constructor.
      *
-     * @param OptionValues $options Parsed option values
+     * @param OptionValues $options Parsed option values (legacy, or global when no context)
      * @param array<int, string> $arguments Positional arguments
      * @param array<int, string> $unknown Unknown options (if allowed)
+     * @param OptionValues|null $globalOptions Global options (when contexts used)
+     * @param OptionValues|null $contextOptions Context-specific options (when context active)
+     * @param string|null $context Activated context name (null if no context)
      */
     public function __construct(
         public OptionValues $options,
         public array $arguments,
         public array $unknown = [],
+        public ?OptionValues $globalOptions = null,
+        public ?OptionValues $contextOptions = null,
+        public ?string $context = null,
     ) {
     }
 
@@ -65,7 +79,34 @@ readonly class ParseResult
     }
 
     /**
+     * Check if a context is active.
+     *
+     * @return bool True if context was activated
+     */
+    public function hasContext(): bool
+    {
+        return $this->context !== null;
+    }
+
+    /**
+     * Get the active context name.
+     *
+     * @return string|null Context name or null
+     */
+    public function getContext(): ?string
+    {
+        return $this->context;
+    }
+
+    /**
      * Convenience method for accessing options.
+     *
+     * When contexts are used:
+     * - Checks contextOptions first (if context active)
+     * - Falls back to globalOptions
+     *
+     * When no contexts:
+     * - Returns from options property (backward compatible)
      *
      * Shorthand for $result->options->get($name, $default)
      *
@@ -75,6 +116,48 @@ readonly class ParseResult
      */
     public function getOption(string $name, mixed $default = null): mixed
     {
+        // Context mode: check context first, then global
+        if ($this->hasContext() && $this->contextOptions !== null) {
+            if ($this->contextOptions->has($name)) {
+                return $this->contextOptions->get($name, $default);
+            }
+            if ($this->globalOptions !== null) {
+                return $this->globalOptions->get($name, $default);
+            }
+            return $default;
+        }
+
+        // Legacy mode: use options property
         return $this->options->get($name, $default);
+    }
+
+    /**
+     * Check if an option exists.
+     *
+     * When contexts are used:
+     * - Checks contextOptions first (if context active)
+     * - Then checks globalOptions
+     *
+     * When no contexts:
+     * - Checks options property (backward compatible)
+     *
+     * @param string $name Option name (destination)
+     * @return bool True if option exists
+     */
+    public function hasOption(string $name): bool
+    {
+        // Context mode: check context first, then global
+        if ($this->hasContext() && $this->contextOptions !== null) {
+            if ($this->contextOptions->has($name)) {
+                return true;
+            }
+            if ($this->globalOptions !== null) {
+                return $this->globalOptions->has($name);
+            }
+            return false;
+        }
+
+        // Legacy mode: use options property
+        return $this->options->has($name);
     }
 }

--- a/src/Modern/Result/ParseResult.php
+++ b/src/Modern/Result/ParseResult.php
@@ -55,8 +55,7 @@ readonly class ParseResult
         public ?OptionValues $globalOptions = null,
         public ?OptionValues $contextOptions = null,
         public ?string $context = null,
-    ) {
-    }
+    ) {}
 
     /**
      * Check if unknown options were encountered.

--- a/src/Modern/Validator/Validators.php
+++ b/src/Modern/Validator/Validators.php
@@ -65,7 +65,7 @@ class Validators
     public static function regex(string $pattern, string $description = ''): callable
     {
         return function (mixed $value) use ($pattern, $description): bool|string {
-            if (!preg_match($pattern, (string)$value)) {
+            if (!preg_match($pattern, (string) $value)) {
                 $msg = $description ?: "Value must match pattern {$pattern}";
                 return $msg;
             }
@@ -83,7 +83,7 @@ class Validators
     public static function file(bool $mustExist = true, bool $mustBeReadable = false): callable
     {
         return function (mixed $value) use ($mustExist, $mustBeReadable): bool|string {
-            $path = (string)$value;
+            $path = (string) $value;
 
             if ($mustExist && !file_exists($path)) {
                 return "File not found: {$path}";
@@ -107,7 +107,7 @@ class Validators
     public static function directory(bool $mustExist = true, bool $mustBeWritable = false): callable
     {
         return function (mixed $value) use ($mustExist, $mustBeWritable): bool|string {
-            $path = (string)$value;
+            $path = (string) $value;
 
             if ($mustExist && !is_dir($path)) {
                 return "Directory not found: {$path}";
@@ -147,7 +147,7 @@ class Validators
     public static function minLength(int $length): callable
     {
         return function (mixed $value) use ($length): bool|string {
-            if (strlen((string)$value) < $length) {
+            if (strlen((string) $value) < $length) {
                 return "Value must be at least {$length} characters";
             }
             return true;
@@ -163,7 +163,7 @@ class Validators
     public static function maxLength(int $length): callable
     {
         return function (mixed $value) use ($length): bool|string {
-            if (strlen((string)$value) > $length) {
+            if (strlen((string) $value) > $length) {
                 return "Value must be at most {$length} characters";
             }
             return true;

--- a/src/Option.php
+++ b/src/Option.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,11 +15,12 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
+
 use Iterator;
 use InvalidArgumentException;
 use RuntimeException;
-
 
 /**
  * Defines the Option class and some standard value-checking functions.
@@ -48,14 +50,14 @@ use RuntimeException;
  */
 class Option
 {
-    const SUPPRESS_HELP = 'SUPPRESS HELP';
-    const SUPPRESS_USAGE = 'SUPPRESS USAGE';
+    public const SUPPRESS_HELP = 'SUPPRESS HELP';
+    public const SUPPRESS_USAGE = 'SUPPRESS USAGE';
 
     /**
      * Not supplying a default is different from a default of None,
      * so we need an explicit 'not supplied' value.
      */
-    public static $NO_DEFAULT = array('NO', 'DEFAULT');
+    public static $NO_DEFAULT = ['NO', 'DEFAULT'];
 
     public static function parseNumber($value)
     {
@@ -103,25 +105,30 @@ class Option
     public function checkBuiltin($opt, $value)
     {
         switch ($this->type) {
-        case 'int':
-        case 'long':
-            $number = self::parseNumber($value);
-            if ($number === false) {
-                $message = $this->type == 'int'
-                    ? Translation::t("option %s: invalid integer value: '%s'")
-                    : Translation::t("option %s: invalid long integer value: '%s'");
-                throw new OptionValueException(
-                    sprintf($message, $opt, $value));
-            }
-            return $number;
+            case 'int':
+            case 'long':
+                $number = self::parseNumber($value);
+                if ($number === false) {
+                    $message = $this->type == 'int'
+                        ? Translation::t("option %s: invalid integer value: '%s'")
+                        : Translation::t("option %s: invalid long integer value: '%s'");
+                    throw new OptionValueException(
+                        sprintf($message, $opt, $value)
+                    );
+                }
+                return $number;
 
-        case 'float':
-            if (!is_numeric($value)) {
-                throw new OptionValueException(
-                    sprintf(Translation::t("option %s: invalid floating-point value: '%s'"),
-                            $opt, $value));
-            }
-            return floatval($value);
+            case 'float':
+                if (!is_numeric($value)) {
+                    throw new OptionValueException(
+                        sprintf(
+                            Translation::t("option %s: invalid floating-point value: '%s'"),
+                            $opt,
+                            $value
+                        )
+                    );
+                }
+                return floatval($value);
         }
     }
 
@@ -130,14 +137,17 @@ class Option
         if (in_array($value, $this->choices)) {
             return $value;
         } else {
-            $choices = array();
+            $choices = [];
             foreach ($this->choices as $choice) {
-                $choices[] = (string)$choice;
+                $choices[] = (string) $choice;
             }
             $choices = "'" . implode("', '", $choices) . "'";
             throw new OptionValueException(sprintf(
                 Translation::t("option %s: invalid choice: '%s' (choose from %s)"),
-                $opt, $value, $choices));
+                $opt,
+                $value,
+                $choices
+            ));
         }
     }
 
@@ -146,7 +156,7 @@ class Option
      * The list of instance attributes that may be set through keyword args to
      * the constructor.
      */
-    public $ATTRS = array(
+    public $ATTRS = [
         'action',
         'type',
         'dest',
@@ -158,14 +168,14 @@ class Option
         'callbackArgs',
         'help',
         'metavar',
-    );
-    
+    ];
+
 
     /**
      * The set of actions allowed by option parsers.  Explicitly listed here so
      * the constructor can validate its arguments.
      */
-    public $ACTIONS = array(
+    public $ACTIONS = [
         'store',
         'store_const',
         'store_true',
@@ -176,14 +186,14 @@ class Option
         'callback',
         'help',
         'version',
-    );
+    ];
 
     /**
      * The set of actions that involve storing a value somewhere;
      * also listed just for constructor argument validation.  (If
      * the action is one of these, there must be a destination.)
      */
-    public $STORE_ACTIONS = array(
+    public $STORE_ACTIONS = [
         'store',
         'store_const',
         'store_true',
@@ -191,35 +201,35 @@ class Option
         'append',
         'append_const',
         'count',
-    );
+    ];
 
     /**
      * The set of actions for which it makes sense to supply a value type,
      * ie. which may consume an argument from the command line.
      */
-    public $TYPED_ACTIONS = array(
+    public $TYPED_ACTIONS = [
         'store',
         'append',
         'callback',
-    );
+    ];
 
     /**
      * The set of actions which *require* a value type, ie. that always consume
      * an argument from the command line.
      */
-    public $ALWAYS_TYPED_ACTIONS = array('store', 'append');
+    public $ALWAYS_TYPED_ACTIONS = ['store', 'append'];
 
     /**
      * The set of actions which take a 'const' attribute.
      */
-    public $CONST_ACTIONS = array('store_const', 'append_const');
+    public $CONST_ACTIONS = ['store_const', 'append_const'];
 
     /**
      * The set of known types for option parsers.
      *
      * Again, listed here for constructor argument validation.
      */
-    public $TYPES = array('string', 'int', 'long', 'float', 'complex', 'choice');
+    public $TYPES = ['string', 'int', 'long', 'float', 'complex', 'choice'];
 
     /**
      * Dictionary of argument checking functions, which convert and validate
@@ -242,12 +252,12 @@ class Option
      * If no checker is defined for a type, arguments will be unchecked and
      * remain strings.
      */
-    public $TYPE_CHECKER = array('int'     => 'checkBuiltin',
-                                 'long'    => 'checkBuiltin',
-                                 'float'   => 'checkBuiltin',
-                                 'complex' => 'checkBuiltin',
-                                 'choice'  => 'checkChoice',
-    );
+    public $TYPE_CHECKER = ['int'     => 'checkBuiltin',
+        'long'    => 'checkBuiltin',
+        'float'   => 'checkBuiltin',
+        'complex' => 'checkBuiltin',
+        'choice'  => 'checkChoice',
+    ];
 
     /**
      * A list of unbound method objects.
@@ -259,19 +269,19 @@ class Option
      * that add another _check_*() method should define their own CHECK_METHODS
      * list that adds their check method to those from this class.
      */
-    public $CHECK_METHODS = array('_checkAction',
-                                  '_checkType',
-                                  '_checkChoice',
-                                  '_checkDest',
-                                  '_checkConst',
-                                  '_checkNargs',
-                                  '_checkCallback',
-    );
+    public $CHECK_METHODS = ['_checkAction',
+        '_checkType',
+        '_checkChoice',
+        '_checkDest',
+        '_checkConst',
+        '_checkNargs',
+        '_checkCallback',
+    ];
 
     // -- Constructor/initialization methods ----------------------------
 
-    public $shortOpts = array();
-    public $longOpts = array();
+    public $shortOpts = [];
+    public $longOpts = [];
     // These should probably be made readonly once we are sure we *really* usually set them through a constructor
     public $action;
     public $type;
@@ -286,7 +296,7 @@ class Option
     // TODO: Where is this even used?
     public $metavar;
     // Used in OptionContainer->addOption
-    public $container; 
+    public $container;
 
     /**
      * Constructor.
@@ -300,15 +310,15 @@ class Option
         $opts = func_get_args();
         $num = func_num_args();
         if ($num == 0 || $num == 1 || !is_array($opts[$num - 1])) {
-            $attrs = array();
+            $attrs = [];
         } else {
             $attrs = array_pop($opts);
         }
 
         // Set shortOpts, longOpts attrs from 'opts' tuple.
         // Have to be set now, in case no option strings are supplied.
-        $this->shortOpts = array();
-        $this->longOpts = array();
+        $this->shortOpts = [];
+        $this->longOpts = [];
         $opts = $this->_checkOptStrings($opts);
         $this->_setOptStrings($opts);
 
@@ -321,7 +331,7 @@ class Option
         // could be handy for subclasses!  The one thing these all share
         // is that they raise OptionError if they discover a problem.
         foreach ($this->CHECK_METHODS as $checker) {
-            call_user_func(array($this, $checker));
+            call_user_func([$this, $checker]);
         }
     }
 
@@ -340,22 +350,26 @@ class Option
     protected function _setOptStrings($opts)
     {
         foreach ($opts as &$opt) {
-            $opt = (string)$opt;
+            $opt = (string) $opt;
 
             if (strlen($opt) < 2) {
                 throw new OptionException(sprintf("invalid option string '%s': must be at least two characters long", $opt), $this);
             } elseif (strlen($opt) == 2) {
                 if (!($opt[0] == '-' && $opt[1] != '-')) {
                     throw new OptionException(sprintf(
-                        "invalid short option string '%s': " .
-                        "must be of the form -x, (x any non-dash char)", $opt), $this);
+                        "invalid short option string '%s': "
+                        . "must be of the form -x, (x any non-dash char)",
+                        $opt
+                    ), $this);
                 }
                 $this->shortOpts[] = $opt;
             } else {
                 if (!(substr($opt, 0, 2) == '--' && $opt[2] != '-')) {
                     throw new OptionException(sprintf(
-                        "invalid long option string '%s': " .
-                        "must start with --, followed by non-dash", $opt), $this);
+                        "invalid long option string '%s': "
+                        . "must start with --, followed by non-dash",
+                        $opt
+                    ), $this);
                 }
                 $this->longOpts[] = $opt;
             }
@@ -381,7 +395,9 @@ class Option
             $attrs = array_keys($attrs);
             sort($attrs);
             throw new OptionException(sprintf(
-                'invalid keyword arguments: %s', implode(', ', $attrs)), $this);
+                'invalid keyword arguments: %s',
+                implode(', ', $attrs)
+            ), $this);
         }
     }
 
@@ -420,7 +436,9 @@ class Option
 
             if (!in_array($this->action, $this->TYPED_ACTIONS)) {
                 throw new OptionException(sprintf(
-                    "must not supply a type for action '%s'", $this->action), $this);
+                    "must not supply a type for action '%s'",
+                    $this->action
+                ), $this);
             }
         }
     }
@@ -430,15 +448,20 @@ class Option
         if ($this->type == 'choice') {
             if (is_null($this->choices)) {
                 throw new OptionException(
-                    "must supply a list of choices for type 'choice'", $this);
+                    "must supply a list of choices for type 'choice'",
+                    $this
+                );
             } elseif (!(is_array($this->choices) || $this->choices instanceof Iterator)) {
                 throw new OptionException(sprintf(
                     "choices must be a list of strings ('%s' supplied)",
-                    gettype($this->choices)), $this);
+                    gettype($this->choices)
+                ), $this);
             }
         } elseif (!is_null($this->choices)) {
             throw new OptionException(sprintf(
-                "must not supply choices for type '%s'", $this->type), $this);
+                "must not supply choices for type '%s'",
+                $this->type
+            ), $this);
         }
     }
 
@@ -446,8 +469,8 @@ class Option
     {
         // No destination given, and we need one for this action.  The
         // $this->type check is for callbacks that take a value.
-        $takes_value = (in_array($this->action, $this->STORE_ACTIONS) ||
-                        !is_null($this->type));
+        $takes_value = (in_array($this->action, $this->STORE_ACTIONS)
+                        || !is_null($this->type));
         if (is_null($this->dest) && $takes_value) {
             // Glean a destination from the first long option string,
             // or from the first short option string if no long options.
@@ -463,9 +486,13 @@ class Option
     public function _checkConst()
     {
         if (!in_array($this->action, $this->CONST_ACTIONS) && !is_null($this->const)) {
-            throw new OptionException(sprintf(
-                "'const' must not be supplied for action '%s'", $this->action),
-                $this);
+            throw new OptionException(
+                sprintf(
+                    "'const' must not be supplied for action '%s'",
+                    $this->action
+                ),
+                $this
+            );
         }
     }
 
@@ -476,9 +503,13 @@ class Option
                 $this->nargs = 1;
             }
         } elseif (!is_null($this->nargs)) {
-            throw new OptionException(sprintf(
-                "'nargs' must not be supplied for action '%s'", $this->action),
-                $this);
+            throw new OptionException(
+                sprintf(
+                    "'nargs' must not be supplied for action '%s'",
+                    $this->action
+                ),
+                $this
+            );
         }
     }
 
@@ -491,32 +522,38 @@ class Option
                 $callback_name = '';
                 if (is_array($this->callback)) {
                     if (is_object($this->callback[0])) {
-                        $callback_name = get_class($this->callback[0]) . '#' .  $this->callback[1];
+                        $callback_name = get_class($this->callback[0]) . '#' . $this->callback[1];
                     } else {
                         $callback_name = implode('#', $this->callback);
-                        }
+                    }
                 } else {
                     throw new OptionException(sprintf(
-                        "callback not callable: '%s'", $callback_name), $this);
+                        "callback not callable: '%s'",
+                        $callback_name
+                    ), $this);
                 }
             }
             if (!is_null($this->callbackArgs) && !is_array($this->callbackArgs)) {
                 throw new OptionException(sprintf(
                     "callbackArgs, if supplied, must be an array: not '%s'",
-                    $this->callbackArgs), $this);
+                    $this->callbackArgs
+                ), $this);
             }
         } else {
             if (!is_null($this->callback)) {
-                $callback_name = is_array($this->callback) ?
-                    is_object($this->callback[0]) ? get_class($this->callback[0]) . '#' . $this->callback[1] : implode('#', $this->callback) :
-                    $this->callback;
+                $callback_name = is_array($this->callback)
+                    ? is_object($this->callback[0]) ? get_class($this->callback[0]) . '#' . $this->callback[1] : implode('#', $this->callback)
+                    : $this->callback;
                 throw new OptionException(sprintf(
                     "callback supplied ('%s') for non-callback option",
-                    $callback_name), $this);
+                    $callback_name
+                ), $this);
             }
             if (!is_null($this->callbackArgs)) {
                 throw new OptionException(
-                    'callbackArgs supplied for non-callback option', $this);
+                    'callbackArgs supplied for non-callback option',
+                    $this
+                );
             }
         }
     }
@@ -557,7 +594,7 @@ class Option
             return $value;
         }
         $checker = $this->TYPE_CHECKER[$this->type];
-        return call_user_func(array($this, $checker), $opt, $value);
+        return call_user_func([$this, $checker], $opt, $value);
     }
 
     public function convertValue($opt, $value)
@@ -566,7 +603,7 @@ class Option
             if ($this->nargs == 1) {
                 return $this->checkValue($opt, $value);
             } else {
-                $return = array();
+                $return = [];
                 foreach ($value as $v) {
                     $return[] = $this->checkValue($opt, $v);
                 }
@@ -585,7 +622,13 @@ class Option
         // This is a separate method to make life easier for
         // subclasses to add new actions.
         return $this->takeAction(
-            $this->action, $this->dest, $opt, $value, $values, $parser);
+            $this->action,
+            $this->dest,
+            $opt,
+            $value,
+            $values,
+            $parser
+        );
     }
 
     public function takeAction($action, $dest, $opt, $value, $values, $parser)

--- a/src/OptionConflictException.php
+++ b/src/OptionConflictException.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,6 +15,7 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
 
 /**
@@ -26,5 +28,4 @@ namespace Horde\Argv;
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/bsd BSD
  */
-class OptionConflictException extends OptionException
-{}
+class OptionConflictException extends OptionException {}

--- a/src/OptionContainer.php
+++ b/src/OptionContainer.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,6 +15,7 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
 
 use Horde_Argv_Option;
@@ -58,11 +60,11 @@ use ReflectionClass;
 class OptionContainer
 {
     public $description = '';
-    public $optionList = array();
+    public $optionList = [];
     public $optionClass = Option::class;
-    public $defaults = array();
-    public $shortOpt = array();
-    public $longOpt = array();
+    public $defaults = [];
+    public $shortOpt = [];
+    public $longOpt = [];
     public $conflictHandler;
 
     /**
@@ -87,9 +89,9 @@ class OptionContainer
      */
     protected function _createOptionMappings()
     {
-        $this->shortOpt = array();       // single letter -> Option instance
-        $this->longOpt = array();        // long option -> Option instance
-        $this->defaults = array();       // maps option dest -> default value
+        $this->shortOpt = [];       // single letter -> Option instance
+        $this->longOpt = [];        // long option -> Option instance
+        $this->defaults = [];       // maps option dest -> default value
     }
 
     /**
@@ -98,14 +100,14 @@ class OptionContainer
      */
     protected function _shareOptionMappings($parser)
     {
-        $this->shortOpt =& $parser->shortOpt;
-        $this->longOpt =& $parser->longOpt;
+        $this->shortOpt = & $parser->shortOpt;
+        $this->longOpt = & $parser->longOpt;
         $this->defaults = $parser->defaults;
     }
 
     public function setConflictHandler($handler)
     {
-        if (!in_array($handler, array('error', 'resolve'))) {
+        if (!in_array($handler, ['error', 'resolve'])) {
             throw new InvalidArgumentException('invalid conflictHandler ' . var_export($handler, true));
         }
         $this->conflictHandler = $handler;
@@ -125,7 +127,7 @@ class OptionContainer
 
     protected function _checkConflict($option)
     {
-        $conflictOpts = array();
+        $conflictOpts = [];
         foreach ($option->shortOpts as $opt) {
             if (isset($this->shortOpt[$opt])) {
                 $conflictOpts[$opt] = $this->shortOpt[$opt];
@@ -142,7 +144,8 @@ class OptionContainer
             if ($handler == 'error') {
                 throw new OptionConflictException(sprintf(
                     'conflicting option string(s): %s',
-                    implode(', ', array_keys($conflictOpts))), $option);
+                    implode(', ', array_keys($conflictOpts))
+                ), $option);
             } elseif ($handler == 'resolve') {
                 foreach ($conflictOpts as $opt => $c_option) {
                     if (strncmp($opt, '--', 2) === 0) {
@@ -177,8 +180,9 @@ class OptionContainer
             $option = $optionFactory->newInstanceArgs($opts);
         } elseif (count($opts) == 1) {
             $option = $opts[0];
-            if (!$option instanceof Option)
+            if (!$option instanceof Option) {
                 throw new InvalidArgumentException('not an Option instance: ' . var_export($option, true));
+            }
         } else {
             throw new InvalidArgumentException('invalid arguments');
         }
@@ -254,12 +258,14 @@ class OptionContainer
 
     public function formatOptionHelp($formatter = null)
     {
-        if (!$this->optionList)
+        if (!$this->optionList) {
             return '';
-        $result = array();
+        }
+        $result = [];
         foreach ($this->optionList as $option) {
-            if ($option->help != Option::SUPPRESS_HELP)
+            if ($option->help != Option::SUPPRESS_HELP) {
                 $result[] = $formatter->formatOption($option);
+            }
         }
         return implode('', $result);
     }
@@ -271,11 +277,13 @@ class OptionContainer
 
     public function formatHelp($formatter = null)
     {
-        $result = array();
-        if ($this->description)
+        $result = [];
+        if ($this->description) {
             $result[] = $this->formatDescription($formatter);
-        if ($this->optionList)
+        }
+        if ($this->optionList) {
             $result[] = $this->formatOptionHelp($formatter);
+        }
         return implode("\n", $result);
     }
 

--- a/src/OptionException.php
+++ b/src/OptionException.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,6 +15,7 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
 
 /**
@@ -32,7 +34,7 @@ class OptionException extends Exception
     public string $optionId;
     public function __construct($msg, $option = null)
     {
-        $this->optionId = (string)$option;
+        $this->optionId = (string) $option;
         if ($this->optionId) {
             parent::__construct(sprintf('option %s: %s', $this->optionId, $msg));
         } else {

--- a/src/OptionGroup.php
+++ b/src/OptionGroup.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,6 +15,7 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
 
 /**
@@ -41,7 +43,7 @@ class OptionGroup extends OptionContainer
 
     protected function _createOptionList()
     {
-        $this->optionList = array();
+        $this->optionList = [];
         $this->_shareOptionMappings($this->parser);
     }
 
@@ -59,8 +61,9 @@ class OptionGroup extends OptionContainer
 
     public function formatHelp($formatter = null)
     {
-        if (is_null($formatter))
+        if (is_null($formatter)) {
             return '';
+        }
 
         $result = $formatter->formatHeading($this->_title);
         $formatter->indent();

--- a/src/OptionValueException.php
+++ b/src/OptionValueException.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,6 +15,7 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
 
 /**
@@ -26,5 +28,4 @@ namespace Horde\Argv;
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/bsd BSD
  */
-class OptionValueException extends OptionException
-{}
+class OptionValueException extends OptionException {}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2020 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,9 +15,12 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
+
 use ReflectionClass;
 use InvalidArgumentException;
+
 /**
  * Horde command-line argument parsing package.
  *
@@ -98,9 +102,9 @@ class Parser extends OptionContainer implements ArgvParser
     public $version;
     public $allowUnknownArgs;
 
-    public function __construct($args = array())
+    public function __construct($args = [])
     {
-        $args = array_merge(array(
+        $args = array_merge([
             'usage' => null,
             'optionList' => null,
             'optionClass' => Option::class,
@@ -114,7 +118,7 @@ class Parser extends OptionContainer implements ArgvParser
             'allowInterspersedArgs' => true,
             'allowUnknownArgs' => false,
             'ignoreUnknownArgs' => false,
-            ), $args);
+        ], $args);
 
         parent::__construct($args['optionClass'], $args['conflictHandler'], $args['description']);
         $this->setUsage($args['usage']);
@@ -134,8 +138,10 @@ class Parser extends OptionContainer implements ArgvParser
         // standardOptionList class attribute, the 'optionList'
         // argument, and (if applicable) the _addVersionOption() and
         // _addHelpOption() methods.
-        $this->_populateOptionList($args['optionList'],
-                                   $args['addHelpOption']);
+        $this->_populateOptionList(
+            $args['optionList'],
+            $args['addHelpOption']
+        );
 
         $this->_initParsingState();
     }
@@ -145,33 +151,37 @@ class Parser extends OptionContainer implements ArgvParser
 
     protected function _createOptionList()
     {
-        $this->optionList = array();
-        $this->optionGroups = array();
+        $this->optionList = [];
+        $this->optionGroups = [];
         $this->_createOptionMappings();
     }
 
     protected function _addHelpOption()
     {
-        $this->addOption('-h', '--help', array('action' => 'help',
-                                               'help' => Translation::t("show this help message and exit")));
+        $this->addOption('-h', '--help', ['action' => 'help',
+            'help' => Translation::t("show this help message and exit")]);
     }
 
     protected function _addVersionOption()
     {
-        $this->addOption('--version', array('action' => 'version',
-                                            'help' => Translation::t("show program's version number and exit")));
+        $this->addOption('--version', ['action' => 'version',
+            'help' => Translation::t("show program's version number and exit")]);
     }
 
     protected function _populateOptionList($optionList, $add_help = true)
     {
-        if ($this->standardOptionList)
+        if ($this->standardOptionList) {
             $this->addOptions($this->standardOptionList);
-        if ($optionList)
+        }
+        if ($optionList) {
             $this->addOptions($optionList);
-        if ($this->version)
+        }
+        if ($this->version) {
             $this->_addVersionOption();
-        if ($add_help)
+        }
+        if ($add_help) {
             $this->_addHelpOption();
+        }
     }
 
     protected function _initParsingState()
@@ -186,12 +196,13 @@ class Parser extends OptionContainer implements ArgvParser
 
     public function setUsage($usage)
     {
-        if (is_null($usage))
+        if (is_null($usage)) {
             $this->_usage = '%prog ' . Translation::t("[options]");
-        elseif ($usage == Option::SUPPRESS_USAGE)
+        } elseif ($usage == Option::SUPPRESS_USAGE) {
             $this->_usage = null;
-        else
+        } else {
             $this->_usage = $usage;
+        }
     }
 
     public function enableInterspersedArgs()
@@ -227,7 +238,7 @@ class Parser extends OptionContainer implements ArgvParser
     {
         $defaults = $this->defaults;
         foreach ($this->_getAllOptions() as $option) {
-            $default = isset($defaults[$option->dest]) ? $defaults[$option->dest] : null;
+            $default = $defaults[$option->dest] ?? null;
             if (is_string($default)) {
                 $opt_str = $option->getOptString();
                 $defaults[$option->dest] = $option->checkValue($opt_str, $default);
@@ -251,10 +262,12 @@ class Parser extends OptionContainer implements ArgvParser
             $group = $groupFactory->newInstanceArgs($args);
         } elseif (count($args) == 1) {
             $group = $args[0];
-            if (!$group instanceof OptionGroup)
+            if (!$group instanceof OptionGroup) {
                 throw new InvalidArgumentException("not an OptionGroup instance: " . var_export($group, true));
-            if ($group->parser !== $this)
+            }
+            if ($group->parser !== $this) {
                 throw new InvalidArgumentException("invalid OptionGroup (wrong parser)");
+            }
         } else {
             throw new InvalidArgumentException('invalid arguments');
         }
@@ -306,9 +319,10 @@ class Parser extends OptionContainer implements ArgvParser
     public function parseArgs($args = null, $values = null)
     {
         $rargs = $this->_getArgs($args);
-        $largs = array();
-        if (is_null($values))
+        $largs = [];
+        if (is_null($values)) {
             $values = $this->getDefaultValues();
+        }
 
         // Store the halves of the argument list as attributes for the
         // convenience of callbacks:
@@ -319,8 +333,8 @@ class Parser extends OptionContainer implements ArgvParser
         //     the leftover arguments -- ie. what's left after removing
         //     options and their arguments (the "l" stands for "leftover"
         //     or "left-hand")
-        $this->rargs =& $rargs;
-        $this->largs =& $largs;
+        $this->rargs = & $rargs;
+        $this->largs = & $largs;
         $this->values = $values;
 
         try {
@@ -344,7 +358,7 @@ class Parser extends OptionContainer implements ArgvParser
      */
     public function checkValues($values, $args)
     {
-        return array($values, $args);
+        return [$values, $args];
     }
 
     /**
@@ -431,7 +445,7 @@ class Parser extends OptionContainer implements ArgvParser
         }
 
         // Isolate all words with s as a prefix.
-        $possibilities = array();
+        $possibilities = [];
         foreach (array_keys($wordmap) as $word) {
             if (strncmp($word, $s, strlen($s)) === 0) {
                 $possibilities[] = $word;
@@ -457,7 +471,7 @@ class Parser extends OptionContainer implements ArgvParser
         // Value explicitly attached to arg?  Pretend it's the next
         // argument.
         if (strpos($arg, '=') !== false) {
-            list($opt, $next_arg) = explode('=', $arg, 2);
+            [$opt, $next_arg] = explode('=', $arg, 2);
             array_unshift($rargs, $next_arg);
             $had_explicit_value = true;
         } else {
@@ -473,7 +487,7 @@ class Parser extends OptionContainer implements ArgvParser
                 return;
             }
             if ($this->allowUnknownArgs) {
-                $option = $this->addOption($opt, array('default' => true, 'action' => 'append'));
+                $option = $this->addOption($opt, ['default' => true, 'action' => 'append']);
             } else {
                 throw $e;
             }
@@ -513,12 +527,12 @@ class Parser extends OptionContainer implements ArgvParser
         for ($c = 1, $c_max = strlen($arg); $c < $c_max; $c++) {
             $ch = $arg[$c];
             $opt = '-' . $ch;
-            $option = isset($this->shortOpt[$opt]) ? $this->shortOpt[$opt] : null;
+            $option = $this->shortOpt[$opt] ?? null;
             $i++; // we have consumed a character
 
             if (!$option) {
                 if ($this->allowUnknownArgs) {
-                    $option = $this->addOption($opt, array('default' => true, 'action' => 'append'));
+                    $option = $this->addOption($opt, ['default' => true, 'action' => 'append']);
                 } elseif ($this->ignoreUnknownArgs) {
                     continue;
                 } else {
@@ -556,7 +570,9 @@ class Parser extends OptionContainer implements ArgvParser
 
             $option->process($opt, $value, $values, $this);
 
-            if ($stop) { break; }
+            if ($stop) {
+                break;
+            }
         }
     }
 
@@ -564,10 +580,11 @@ class Parser extends OptionContainer implements ArgvParser
 
     public function getProgName()
     {
-        if (is_null($this->prog))
+        if (is_null($this->prog)) {
             return basename($_SERVER['argv'][0]);
-        else
+        } else {
             return $this->prog;
+        }
     }
 
     public function expandProgName($s)
@@ -582,8 +599,9 @@ class Parser extends OptionContainer implements ArgvParser
 
     public function parserExit($status = 0, $msg = null)
     {
-        if ($msg)
+        if ($msg) {
             fwrite(STDERR, $msg);
+        }
         exit($status);
     }
 
@@ -602,12 +620,14 @@ class Parser extends OptionContainer implements ArgvParser
 
     public function getUsage($formatter = null)
     {
-        if (is_null($formatter))
+        if (is_null($formatter)) {
             $formatter = $this->formatter;
-        if ($this->_usage)
+        }
+        if ($this->_usage) {
             return $formatter->formatUsage($this->expandProgName($this->_usage));
-        else
+        } else {
             return '';
+        }
     }
 
     /**
@@ -621,21 +641,24 @@ class Parser extends OptionContainer implements ArgvParser
      */
     public function printUsage($file = null)
     {
-        if (!$this->_usage)
+        if (!$this->_usage) {
             return;
+        }
 
-        if (is_null($file))
+        if (is_null($file)) {
             echo $this->getUsage();
-        else
+        } else {
             fwrite($file, $this->getUsage());
+        }
     }
 
     public function getVersion()
     {
-        if ($this->version)
+        if ($this->version) {
             return $this->expandProgName($this->version);
-        else
+        } else {
             return '';
+        }
     }
 
     /**
@@ -648,21 +671,24 @@ class Parser extends OptionContainer implements ArgvParser
      */
     public function printVersion($file = null)
     {
-        if (!$this->version)
+        if (!$this->version) {
             return;
+        }
 
-        if (is_null($file))
+        if (is_null($file)) {
             echo $this->getVersion() . "\n";
-        else
+        } else {
             fwrite($file, $this->getVersion() . "\n");
+        }
     }
 
     public function formatOptionHelp($formatter = null)
     {
-        if (is_null($formatter))
+        if (is_null($formatter)) {
             $formatter = $this->formatter;
+        }
         $formatter->storeOptionStrings($this);
-        $result = array();
+        $result = [];
         $result[] = $formatter->formatHeading(Translation::t("Options"));
         $formatter->indent();
         if ($this->optionList) {
@@ -686,13 +712,16 @@ class Parser extends OptionContainer implements ArgvParser
 
     public function formatHelp($formatter = null)
     {
-        if (is_null($formatter))
+        if (is_null($formatter)) {
             $formatter = $this->formatter;
-        $result = array();
-        if ($this->_usage)
+        }
+        $result = [];
+        if ($this->_usage) {
             $result[] = $this->getUsage($formatter) . "\n";
-        if ($this->description)
+        }
+        if ($this->description) {
             $result[] = $this->formatDescription($formatter) . "\n";
+        }
         $result[] = $this->formatOptionHelp($formatter);
         $result[] = $this->formatEpilog($formatter);
         return implode('', $result);
@@ -706,10 +735,11 @@ class Parser extends OptionContainer implements ArgvParser
      */
     public function printHelp($file = null)
     {
-        if (is_null($file))
+        if (is_null($file)) {
             echo $this->formatHelp();
-        else
+        } else {
             fwrite($file, $this->formatHelp());
+        }
     }
 
 }

--- a/src/ParserArgument.php
+++ b/src/ParserArgument.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Horde\Argv\Parser;
 
 /**

--- a/src/ParserBuilder.php
+++ b/src/ParserBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Horde\Argv\Parser;
 
 /**
@@ -20,8 +21,5 @@ namespace Horde\Argv\Parser;
  */
 class ParserBuilder implements Parser
 {
-    public function withArgument(ParserArgument $argument)
-    {
-
-    }
+    public function withArgument(ParserArgument $argument) {}
 }

--- a/src/ParserOption.php
+++ b/src/ParserOption.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Horde\Argv\Parser;
 
 /**

--- a/src/ParserResult.php
+++ b/src/ParserResult.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Horde\Argv\Parser;
 
 /**
@@ -13,7 +14,4 @@ namespace Horde\Argv\Parser;
  * @deprecated This class is under development and not ready for production use.
  *             The API is incomplete and may change without notice. Do not use in production code.
  */
-class ParserResult
-{
-
-}
+class ParserResult {}

--- a/src/TitledHelpFormatter.php
+++ b/src/TitledHelpFormatter.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,6 +15,7 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
 
 /**
@@ -29,12 +31,18 @@ namespace Horde\Argv;
 class TitledHelpFormatter extends HelpFormatter
 {
     public function __construct(
-        $indent_increment = 0, $max_help_position = 24, $width = null,
-        $short_first = false, $color = null
-    )
-    {
+        $indent_increment = 0,
+        $max_help_position = 24,
+        $width = null,
+        $short_first = false,
+        $color = null
+    ) {
         parent::__construct(
-            $indent_increment, $max_help_position, $width, $short_first, $color
+            $indent_increment,
+            $max_help_position,
+            $width,
+            $short_first,
+            $color
         );
     }
 
@@ -49,7 +57,7 @@ class TitledHelpFormatter extends HelpFormatter
 
     public function formatHeading($heading)
     {
-        $prefix = array('=', '-');
+        $prefix = ['=', '-'];
         return $this->highlightHeading(sprintf(
             "%s\n%s\n",
             $heading,

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -11,8 +12,11 @@ declare(strict_types=1);
  * @category Horde
  * @license  http://www.horde.org/licenses/bsd BSD
  */
+
 namespace Horde\Argv;
+
 use Horde\Translation\Autodetect;
+
 /**
  * Horde_Argv_Translation is the translation wrapper class for Horde_Argv.
  *

--- a/src/Values.php
+++ b/src/Values.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 /**
- * Copyright 2010-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2010-2026 Horde LLC (http://www.horde.org/)
  *
  * This package is ported from Python's Optik (http://optik.sourceforge.net/).
  *
@@ -14,7 +15,9 @@ declare(strict_types=1);
  * @category Horde
  * @package  Argv
  */
+
 namespace Horde\Argv;
+
 use ArrayIterator;
 use ArrayAccess;
 use Countable;
@@ -24,7 +27,7 @@ use stdClass;
 
 /**
  * Result hash for Horde_Argv_Parser
- * 
+ *
  * This is a value object and inherently uses dynamic properties. Do not try to "fix" this.
  *
  * @category  Horde
@@ -36,7 +39,7 @@ use stdClass;
  */
 class Values extends stdClass implements IteratorAggregate, ArrayAccess, Countable
 {
-    public function __construct($defaults = array())
+    public function __construct($defaults = [])
     {
         foreach ($defaults as $attr => $val) {
             $this->$attr = $val;
@@ -45,9 +48,9 @@ class Values extends stdClass implements IteratorAggregate, ArrayAccess, Countab
 
     public function __toString(): string
     {
-        $str = array();
+        $str = [];
         foreach ($this as $attr => $val) {
-            $str[] = $attr . ': ' . (string)$val;
+            $str[] = $attr . ': ' . (string) $val;
         }
         return implode(', ', $str);
     }

--- a/test/AllTests.php
+++ b/test/AllTests.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!class_exists(\Horde_Test_AllTests::class)) {
+if (!class_exists(Horde_Test_AllTests::class)) {
     require_once 'Horde/Test/AllTests.php';
 }
 Horde_Test_AllTests::init(__FILE__)->run();

--- a/test/ArgvWrapperTest.php
+++ b/test/ArgvWrapperTest.php
@@ -1,12 +1,17 @@
 <?php
+
 /**
  * @author     Ralf Lang <ralf.lang@ralf-lang.de>
  */
+
 namespace Horde\Argv\Test;
 
 use PHPUnit\Framework\TestCase;
 use Horde\Argv\ArgvWrapper;
 
+/**
+ * @coversNothing
+ */
 class ArgvWrapperTest extends TestCase
 {
     public function testCountArguments()

--- a/test/ContextHelpTest.php
+++ b/test/ContextHelpTest.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2024-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Argv
+ */
+
+namespace Horde\Argv\Test;
+
+use Horde\Argv\Modern\Builder\{ParserBuilder, OptionBuilder, ContextBuilder};
+use Horde\Argv\Modern\Help\HelpFormatter;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Tests for context help generation (Phase 3).
+ *
+ * @category Horde
+ * @package  Argv
+ */
+#[CoversClass(\Horde\Argv\ImmutableParser::class)]
+#[CoversClass(HelpFormatter::class)]
+class ContextHelpTest extends TestCase
+{
+    public function testFormatHelpWithContexts(): void
+    {
+        $deployContext = ContextBuilder::create('deploy')
+            ->withDescription('Deploy application to environment')
+            ->build();
+
+        $rollbackContext = ContextBuilder::create('rollback')
+            ->withDescription('Rollback to previous version')
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->withUsage('%prog [options] <command>')
+            ->withDescription('Application deployment tool')
+            ->addContext($deployContext)
+            ->addContext($rollbackContext)
+            ->build();
+
+        $help = $parser->formatHelp();
+
+        $this->assertStringContainsString('Usage:', $help);
+        $this->assertStringContainsString('Application deployment tool', $help);
+        $this->assertStringContainsString('Commands:', $help);
+        $this->assertStringContainsString('deploy', $help);
+        $this->assertStringContainsString('Deploy application', $help);
+        $this->assertStringContainsString('rollback', $help);
+        $this->assertStringContainsString('Rollback to previous', $help);
+    }
+
+    public function testFormatHelpWithContextAliases(): void
+    {
+        $deployContext = ContextBuilder::create('deploy')
+            ->withDescription('Deploy application')
+            ->withAliases(['dep', 'depl'])
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->build();
+
+        $help = $parser->formatHelp();
+
+        $this->assertStringContainsString('deploy', $help);
+        $this->assertStringContainsString('dep', $help);
+        $this->assertStringContainsString('depl', $help);
+    }
+
+    public function testFormatContextHelp(): void
+    {
+        $forceOpt = OptionBuilder::create()
+            ->long('--force')
+            ->flag()
+            ->help('Force deployment')
+            ->build();
+
+        $timeoutOpt = OptionBuilder::create()
+            ->long('--timeout')
+            ->type(\Horde\Argv\Modern\Enum\OptionType::Int)
+            ->default(60)
+            ->help('Deployment timeout in seconds')
+            ->build();
+
+        $deployContext = ContextBuilder::create('deploy')
+            ->withDescription('Deploy application to environment')
+            ->withUsage('%prog [options] <environment>')
+            ->withHelp('Deploys the application to the specified environment with health checks and rollback capabilities.')
+            ->addOption($forceOpt)
+            ->addOption($timeoutOpt)
+            ->requiresArguments(1, 'environment name')
+            ->build();
+
+        $verboseOpt = OptionBuilder::create()
+            ->short('-v')
+            ->long('--verbose')
+            ->flag()
+            ->help('Verbose output')
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->withProg('myapp')
+            ->addOption($verboseOpt)
+            ->addContext($deployContext)
+            ->build();
+
+        $help = $parser->formatContextHelp('deploy');
+
+        $this->assertStringContainsString('Usage: myapp deploy', $help);
+        $this->assertStringContainsString('Deploy application to environment', $help);
+        $this->assertStringContainsString('Deploys the application', $help);
+        $this->assertStringContainsString('Context Options:', $help);
+        $this->assertStringContainsString('--force', $help);
+        $this->assertStringContainsString('--timeout', $help);
+        $this->assertStringContainsString('Global Options:', $help);
+        $this->assertStringContainsString('--verbose', $help);
+        $this->assertStringContainsString('Arguments:', $help);
+        $this->assertStringContainsString('environment name', $help);
+    }
+
+    public function testFormatContextHelpInvalidContext(): void
+    {
+        $parser = ParserBuilder::create()->build();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown context: nonexistent');
+
+        $parser->formatContextHelp('nonexistent');
+    }
+
+    public function testGetContexts(): void
+    {
+        $deployContext = ContextBuilder::create('deploy')->build();
+        $rollbackContext = ContextBuilder::create('rollback')->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->addContext($rollbackContext)
+            ->build();
+
+        $contexts = $parser->getContexts();
+
+        $this->assertCount(2, $contexts);
+        $this->assertSame('deploy', $contexts[0]->name);
+        $this->assertSame('rollback', $contexts[1]->name);
+    }
+
+    public function testGetContext(): void
+    {
+        $deployContext = ContextBuilder::create('deploy')
+            ->withAliases(['dep'])
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->build();
+
+        // By name
+        $context = $parser->getContext('deploy');
+        $this->assertNotNull($context);
+        $this->assertSame('deploy', $context->name);
+
+        // By alias
+        $context = $parser->getContext('dep');
+        $this->assertNotNull($context);
+        $this->assertSame('deploy', $context->name);
+
+        // Not found
+        $context = $parser->getContext('nonexistent');
+        $this->assertNull($context);
+    }
+
+    public function testHasContexts(): void
+    {
+        $parser1 = ParserBuilder::create()->build();
+        $this->assertFalse($parser1->hasContexts());
+
+        $deployContext = ContextBuilder::create('deploy')->build();
+        $parser2 = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->build();
+        $this->assertTrue($parser2->hasContexts());
+    }
+
+    public function testFormatHelpWithGlobalAndContextOptions(): void
+    {
+        $globalVerbose = OptionBuilder::create()
+            ->long('--verbose')
+            ->flag()
+            ->help('Verbose output')
+            ->build();
+
+        $contextForce = OptionBuilder::create()
+            ->long('--force')
+            ->flag()
+            ->help('Force operation')
+            ->build();
+
+        $deployContext = ContextBuilder::create('deploy')
+            ->withDescription('Deploy application')
+            ->addOption($contextForce)
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->withDescription('Deployment manager')
+            ->addOption($globalVerbose)
+            ->addContext($deployContext)
+            ->build();
+
+        $help = $parser->formatHelp();
+
+        // Should show global options
+        $this->assertStringContainsString('--verbose', $help);
+
+        // Context-specific options shown in context help, not main help
+        $contextHelp = $parser->formatContextHelp('deploy');
+        $this->assertStringContainsString('--force', $contextHelp);
+    }
+
+    public function testFormatContextWithArgumentRequirements(): void
+    {
+        $exactContext = ContextBuilder::create('exact')
+            ->requiresArguments(2, 'source destination')
+            ->build();
+
+        $rangeContext = ContextBuilder::create('range')
+            ->acceptsArguments(1, 3, 'files')
+            ->build();
+
+        $atLeastContext = ContextBuilder::create('atleast')
+            ->requiresAtLeast(1)
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($exactContext)
+            ->addContext($rangeContext)
+            ->addContext($atLeastContext)
+            ->build();
+
+        // Exact count
+        $help1 = $parser->formatContextHelp('exact');
+        $this->assertStringContainsString('Requires exactly 2 arguments', $help1);
+        $this->assertStringContainsString('source destination', $help1);
+
+        // Range
+        $help2 = $parser->formatContextHelp('range');
+        $this->assertStringContainsString('Accepts 1-3 arguments', $help2);
+        $this->assertStringContainsString('files', $help2);
+
+        // At least
+        $help3 = $parser->formatContextHelp('atleast');
+        $this->assertStringContainsString('Requires at least 1 argument', $help3);
+    }
+
+    public function testBackwardCompatibilityNoContexts(): void
+    {
+        $verboseOpt = OptionBuilder::create()
+            ->long('--verbose')
+            ->flag()
+            ->help('Verbose output')
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->withUsage('%prog [options] <file>')
+            ->withDescription('Process files')
+            ->addOption($verboseOpt)
+            ->build();
+
+        $help = $parser->formatHelp();
+
+        // Standard help format (no contexts section)
+        $this->assertStringContainsString('Usage:', $help);
+        $this->assertStringContainsString('Process files', $help);
+        $this->assertStringContainsString('--verbose', $help);
+        $this->assertStringNotContainsString('Commands:', $help);
+    }
+
+    public function testCustomFormatter(): void
+    {
+        $deployContext = ContextBuilder::create('deploy')
+            ->withDescription('Deploy application')
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->build();
+
+        $formatter = HelpFormatter::create()
+            ->withWidth(120)
+            ->withIndent(4)
+            ->build();
+
+        $help = $parser->formatHelp($formatter);
+
+        $this->assertStringContainsString('deploy', $help);
+        $this->assertStringContainsString('Deploy application', $help);
+    }
+}

--- a/test/ContextHelpTest.php
+++ b/test/ContextHelpTest.php
@@ -20,6 +20,7 @@ use Horde\Argv\Modern\Builder\{ParserBuilder, OptionBuilder, ContextBuilder};
 use Horde\Argv\Modern\Help\HelpFormatter;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use InvalidArgumentException;
 
 /**
  * Tests for context help generation (Phase 3).
@@ -132,7 +133,7 @@ class ContextHelpTest extends TestCase
     {
         $parser = ParserBuilder::create()->build();
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown context: nonexistent');
 
         $parser->formatContextHelp('nonexistent');

--- a/test/ContextParsingTest.php
+++ b/test/ContextParsingTest.php
@@ -1,0 +1,359 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2024-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Argv
+ */
+
+namespace Horde\Argv\Test;
+
+use Horde\Argv\Modern\Builder\{ParserBuilder, OptionBuilder, ContextBuilder};
+use Horde\Argv\Modern\Exception\InvalidArgumentCountException;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Tests for context parsing (Phase 2).
+ *
+ * @category Horde
+ * @package  Argv
+ */
+#[CoversClass(\Horde\Argv\ImmutableParser::class)]
+class ContextParsingTest extends TestCase
+{
+    public function testBasicContextDetection(): void
+    {
+        $deployContext = ContextBuilder::create('deploy')
+            ->withDescription('Deploy application')
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->build();
+
+        $result = $parser->parse(['deploy']);
+
+        $this->assertTrue($result->hasContext());
+        $this->assertSame('deploy', $result->getContext());
+        $this->assertCount(0, $result->arguments);
+    }
+
+    public function testContextWithArguments(): void
+    {
+        $deployContext = ContextBuilder::create('deploy')
+            ->requiresArguments(1, 'environment')
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->build();
+
+        $result = $parser->parse(['deploy', 'production']);
+
+        $this->assertSame('deploy', $result->getContext());
+        $this->assertCount(1, $result->arguments);
+        $this->assertSame('production', $result->arguments[0]);
+    }
+
+    public function testContextWithMultipleArguments(): void
+    {
+        $deployContext = ContextBuilder::create('deploy')
+            ->acceptsArguments(1, 3)
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->build();
+
+        $result = $parser->parse(['deploy', 'production', 'v2.0', 'now']);
+
+        $this->assertSame('deploy', $result->getContext());
+        $this->assertCount(3, $result->arguments);
+        $this->assertSame(['production', 'v2.0', 'now'], $result->arguments);
+    }
+
+    public function testGlobalOptions(): void
+    {
+        $verboseOpt = OptionBuilder::create()
+            ->short('-v')
+            ->long('--verbose')
+            ->flag()
+            ->build();
+
+        $deployContext = ContextBuilder::create('deploy')->build();
+
+        $parser = ParserBuilder::create()
+            ->addOption($verboseOpt)
+            ->addContext($deployContext)
+            ->build();
+
+        $result = $parser->parse(['--verbose', 'deploy']);
+
+        $this->assertTrue($result->hasContext());
+        $this->assertSame('deploy', $result->getContext());
+        $this->assertTrue($result->globalOptions->get('verbose'));
+    }
+
+    public function testContextSpecificOptions(): void
+    {
+        $forceOpt = OptionBuilder::create()
+            ->long('--force')
+            ->flag()
+            ->build();
+
+        $deployContext = ContextBuilder::create('deploy')
+            ->addOption($forceOpt)
+            ->requiresArguments(1)
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->build();
+
+        $result = $parser->parse(['deploy', '--force', 'production']);
+
+        $this->assertSame('deploy', $result->getContext());
+        $this->assertTrue($result->contextOptions->get('force'));
+        $this->assertSame('production', $result->arguments[0]);
+    }
+
+    public function testGlobalAndContextOptions(): void
+    {
+        $globalVerbose = OptionBuilder::create()
+            ->short('-v')
+            ->long('--verbose')
+            ->flag()
+            ->build();
+
+        $contextForce = OptionBuilder::create()
+            ->long('--force')
+            ->flag()
+            ->build();
+
+        $deployContext = ContextBuilder::create('deploy')
+            ->addOption($contextForce)
+            ->requiresArguments(1)
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addOption($globalVerbose)
+            ->addContext($deployContext)
+            ->build();
+
+        $result = $parser->parse(['--verbose', 'deploy', '--force', 'production']);
+
+        $this->assertTrue($result->globalOptions->get('verbose'));
+        $this->assertTrue($result->contextOptions->get('force'));
+        $this->assertSame('production', $result->arguments[0]);
+    }
+
+    public function testGetOptionFallback(): void
+    {
+        $globalVerbose = OptionBuilder::create()
+            ->long('--verbose')
+            ->flag()
+            ->build();
+
+        $contextForce = OptionBuilder::create()
+            ->long('--force')
+            ->flag()
+            ->build();
+
+        $deployContext = ContextBuilder::create('deploy')
+            ->addOption($contextForce)
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addOption($globalVerbose)
+            ->addContext($deployContext)
+            ->build();
+
+        $result = $parser->parse(['--verbose', 'deploy', '--force']);
+
+        // getOption() checks context first, then global
+        $this->assertTrue($result->getOption('force')); // From context
+        $this->assertTrue($result->getOption('verbose')); // From global
+        $this->assertNull($result->getOption('missing')); // Not found
+    }
+
+    public function testContextAlias(): void
+    {
+        $deployContext = ContextBuilder::create('deploy')
+            ->withAliases(['dep'])
+            ->requiresArguments(1)
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->build();
+
+        // Using alias
+        $result1 = $parser->parse(['dep', 'production']);
+        $this->assertSame('deploy', $result1->getContext()); // Returns primary name
+        $this->assertSame('production', $result1->arguments[0]);
+
+        // Using primary name
+        $result2 = $parser->parse(['deploy', 'production']);
+        $this->assertSame('deploy', $result2->getContext());
+    }
+
+    public function testMultipleContexts(): void
+    {
+        $deployContext = ContextBuilder::create('deploy')->build();
+        $rollbackContext = ContextBuilder::create('rollback')->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->addContext($rollbackContext)
+            ->build();
+
+        $result1 = $parser->parse(['deploy']);
+        $this->assertSame('deploy', $result1->getContext());
+
+        $result2 = $parser->parse(['rollback']);
+        $this->assertSame('rollback', $result2->getContext());
+    }
+
+    public function testNoContextDetected(): void
+    {
+        $verboseOpt = OptionBuilder::create()
+            ->long('--verbose')
+            ->flag()
+            ->build();
+
+        $deployContext = ContextBuilder::create('deploy')->build();
+
+        $parser = ParserBuilder::create()
+            ->addOption($verboseOpt)
+            ->addContext($deployContext)
+            ->build();
+
+        // No context in args
+        $result = $parser->parse(['--verbose', 'file.txt']);
+
+        $this->assertFalse($result->hasContext());
+        $this->assertNull($result->getContext());
+        $this->assertTrue($result->globalOptions->get('verbose'));
+        $this->assertSame(['file.txt'], $result->arguments);
+    }
+
+    public function testArgumentCountValidationTooFew(): void
+    {
+        $deployContext = ContextBuilder::create('deploy')
+            ->requiresArguments(2, 'environment version')
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->build();
+
+        $this->expectException(InvalidArgumentCountException::class);
+        $this->expectExceptionMessage("requires exactly 2 arguments, got 1");
+
+        $parser->parse(['deploy', 'production']);
+    }
+
+    public function testArgumentCountValidationTooMany(): void
+    {
+        $deployContext = ContextBuilder::create('deploy')
+            ->requiresExactly(1)
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->build();
+
+        $this->expectException(InvalidArgumentCountException::class);
+        $this->expectExceptionMessage("requires exactly 1 argument, got 2");
+
+        $parser->parse(['deploy', 'production', 'extra']);
+    }
+
+    public function testArgumentCountValidationRange(): void
+    {
+        $deployContext = ContextBuilder::create('deploy')
+            ->acceptsArguments(1, 3)
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addContext($deployContext)
+            ->build();
+
+        // Valid: 1 argument
+        $result1 = $parser->parse(['deploy', 'production']);
+        $this->assertCount(1, $result1->arguments);
+
+        // Valid: 2 arguments
+        $result2 = $parser->parse(['deploy', 'production', 'v2.0']);
+        $this->assertCount(2, $result2->arguments);
+
+        // Valid: 3 arguments
+        $result3 = $parser->parse(['deploy', 'production', 'v2.0', 'now']);
+        $this->assertCount(3, $result3->arguments);
+
+        // Invalid: 0 arguments
+        $this->expectException(InvalidArgumentCountException::class);
+        $parser->parse(['deploy']);
+    }
+
+    public function testContextOptionOverridesGlobal(): void
+    {
+        // Both global and context have --timeout option
+        $globalTimeout = OptionBuilder::create()
+            ->long('--timeout')
+            ->type(\Horde\Argv\Modern\Enum\OptionType::Int)
+            ->default(30)
+            ->build();
+
+        $contextTimeout = OptionBuilder::create()
+            ->long('--timeout')
+            ->type(\Horde\Argv\Modern\Enum\OptionType::Int)
+            ->default(60)
+            ->build();
+
+        $deployContext = ContextBuilder::create('deploy')
+            ->addOption($contextTimeout)
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->addOption($globalTimeout)
+            ->addContext($deployContext)
+            ->build();
+
+        $result = $parser->parse(['deploy', '--timeout', '120']);
+
+        // Context option should be set
+        $this->assertSame(120, $result->contextOptions->get('timeout'));
+        // Global option should still have default
+        $this->assertSame(30, $result->globalOptions->get('timeout'));
+    }
+
+    public function testBackwardCompatibilityNoContexts(): void
+    {
+        $verboseOpt = OptionBuilder::create()
+            ->long('--verbose')
+            ->flag()
+            ->build();
+
+        // Parser with no contexts - should behave like legacy
+        $parser = ParserBuilder::create()
+            ->addOption($verboseOpt)
+            ->build();
+
+        $result = $parser->parse(['--verbose', 'file.txt']);
+
+        // Legacy mode behavior
+        $this->assertFalse($result->hasContext());
+        $this->assertTrue($result->options->get('verbose'));
+        $this->assertSame(['file.txt'], $result->arguments);
+    }
+}

--- a/test/Horde/Argv/AllTests.php
+++ b/test/Horde/Argv/AllTests.php
@@ -1,4 +1,5 @@
 <?php
+
 use Horde\Tests\AllTests;
 
 if (class_exists(AllTests::class)) {

--- a/test/Horde/Argv/BoolTest.php
+++ b/test/Horde/Argv/BoolTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Parser;
+
+use Horde_Argv_Parser;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Parser;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class BoolTest extends TestCase
@@ -17,45 +19,59 @@ class BoolTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $options = array(
-            $this->makeOption('-v', '--verbose',
-                        array('action' => 'store_true', 'dest' => 'verbose', 'default' => '')),
-            $this->makeOption('-q', '--quiet',
-                        array('action' => 'store_false', 'dest' => 'verbose'))
-        );
+        $options = [
+            $this->makeOption(
+                '-v',
+                '--verbose',
+                ['action' => 'store_true', 'dest' => 'verbose', 'default' => '']
+            ),
+            $this->makeOption(
+                '-q',
+                '--quiet',
+                ['action' => 'store_false', 'dest' => 'verbose']
+            ),
+        ];
 
-        $this->parser = new Horde_Argv_Parser(array('optionList' => $options));
+        $this->parser = new Horde_Argv_Parser(['optionList' => $options]);
     }
 
     public function testBoolDefault()
     {
-        $this->assertParseOk(array(),
-                             array('verbose' => ''),
-                             array());
+        $this->assertParseOk(
+            [],
+            ['verbose' => ''],
+            []
+        );
     }
 
     public function testBoolFalse()
     {
-        list($options, $args) = $this->assertParseOk(array('-q'),
-                                                     array('verbose' => false),
-                                                     array());
+        [$options, $args] = $this->assertParseOk(
+            ['-q'],
+            ['verbose' => false],
+            []
+        );
 
         $this->assertSame(false, $options->verbose);
     }
 
     public function testBoolTrue()
     {
-        list($options, $args) = $this->assertParseOk(array('-v'),
-                                                     array('verbose' => true),
-                                                     array());
+        [$options, $args] = $this->assertParseOk(
+            ['-v'],
+            ['verbose' => true],
+            []
+        );
         $this->assertSame(true, $options->verbose);
     }
 
     public function testBoolFlickerOnAndOff()
     {
-        $this->assertParseOk(array('-qvq', '-q', '-v'),
-                             array('verbose' => true),
-                             array());
+        $this->assertParseOk(
+            ['-qvq', '-q', '-v'],
+            ['verbose' => true],
+            []
+        );
     }
 
 }

--- a/test/Horde/Argv/CallbackCheckAbbrevTest.php
+++ b/test/Horde/Argv/CallbackCheckAbbrevTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Parser;
+
+use Horde_Argv_Parser;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Parser;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class CallbackCheckAbbrevTest extends TestCase
@@ -18,8 +20,8 @@ class CallbackCheckAbbrevTest extends TestCase
     {
         parent::setUp();
         $this->parser = new Horde_Argv_Parser();
-        $this->parser->addOption('--foo-bar', array('action' => 'callback',
-                                                    'callback' => array($this, 'checkAbbrev')));
+        $this->parser->addOption('--foo-bar', ['action' => 'callback',
+            'callback' => [$this, 'checkAbbrev']]);
     }
 
     public function checkAbbrev($option, $opt, $value, $parser)
@@ -29,6 +31,6 @@ class CallbackCheckAbbrevTest extends TestCase
 
     public function testAbbrevCallbackExpansion()
     {
-        $this->assertParseOk(array('--foo'), array(), array());
+        $this->assertParseOk(['--foo'], [], []);
     }
 }

--- a/test/Horde/Argv/CallbackExtraArgsTest.php
+++ b/test/Horde/Argv/CallbackExtraArgsTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Parser;
+
+use Horde_Argv_Parser;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Parser;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class CallbackExtraArgsTest extends TestCase
@@ -17,25 +19,25 @@ class CallbackExtraArgsTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $options = array(
-            $this->makeOption('-p', '--point', array('action' => 'callback',
-                'callback' => array($this, 'processTuple'),
-                'callbackArgs' => array(3, 'int'), 'type' => 'string',
-                'dest' => 'points', 'default' => array())),
-        );
-        $this->parser = new Horde_Argv_Parser(array('optionList' => $options));
+        $options = [
+            $this->makeOption('-p', '--point', ['action' => 'callback',
+                'callback' => [$this, 'processTuple'],
+                'callbackArgs' => [3, 'int'], 'type' => 'string',
+                'dest' => 'points', 'default' => []]),
+        ];
+        $this->parser = new Horde_Argv_Parser(['optionList' => $options]);
     }
 
     public function processTuple($option, $opt, $value, $parser, $args)
     {
-        list($len, $type) = $args;
+        [$len, $type] = $args;
 
         $this->assertEquals(3, $len);
         $this->assertEquals('int', $type);
 
         if ($opt == '-p') {
             $this->assertEquals('1,2,3', $value);
-        } else if ($option == '--point') {
+        } elseif ($option == '--point') {
             $this->assertEquals('4,5,6', $value);
         }
 
@@ -49,9 +51,11 @@ class CallbackExtraArgsTest extends TestCase
 
     public function testCallbackExtraArgs()
     {
-        $this->assertParseOk(array("-p1,2,3", "--point", "4,5,6"),
-                             array('points' => array(array(1,2,3), array(4,5,6))),
-                             array());
+        $this->assertParseOk(
+            ["-p1,2,3", "--point", "4,5,6"],
+            ['points' => [[1,2,3], [4,5,6]]],
+            []
+        );
     }
 
 }

--- a/test/Horde/Argv/CallbackManyArgsTest.php
+++ b/test/Horde/Argv/CallbackManyArgsTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Parser;
+
+use Horde_Argv_Parser;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Parser;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class CallbackManyArgsTest extends TestCase
@@ -17,35 +19,37 @@ class CallbackManyArgsTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $options = array(
-            $this->makeOption('-a', '--apple', array('action' => 'callback', 'nargs' => 2,
-                                                        'callback' => array($this, 'processMany'), 'type' => 'string')),
-            $this->makeOption('-b', '--bob', array('action' => 'callback', 'nargs' => 3,
-                                                       'callback' => array($this, 'processMany'), 'type' => 'int'))
-        );
+        $options = [
+            $this->makeOption('-a', '--apple', ['action' => 'callback', 'nargs' => 2,
+                'callback' => [$this, 'processMany'], 'type' => 'string']),
+            $this->makeOption('-b', '--bob', ['action' => 'callback', 'nargs' => 3,
+                'callback' => [$this, 'processMany'], 'type' => 'int']),
+        ];
 
-        $this->parser = new Horde_Argv_Parser(array('optionList' => $options));
+        $this->parser = new Horde_Argv_Parser(['optionList' => $options]);
     }
 
     public function processMany($option, $opt, $value, $parser_)
     {
         if ($opt == '-a') {
-            $this->assertEquals(array('foo', 'bar'), $value);
-        } else if ($opt == '--apple') {
-            $this->assertEquals(array('ding', 'dong'), $value);
-        } else if ($opt == '-b') {
-            $this->assertEquals(array(1, 2, 3), $value);
-        } else if ($option == '--bob') {
-            $this->assertEquals(array(-666, 42, 0), $value);
+            $this->assertEquals(['foo', 'bar'], $value);
+        } elseif ($opt == '--apple') {
+            $this->assertEquals(['ding', 'dong'], $value);
+        } elseif ($opt == '-b') {
+            $this->assertEquals([1, 2, 3], $value);
+        } elseif ($option == '--bob') {
+            $this->assertEquals([-666, 42, 0], $value);
         }
     }
 
     public function testManyArgs()
     {
-        $this->assertParseOk(array("-a", "foo", "bar", "--apple", "ding", "dong",
-                             "-b", "1", "2", "3", "--bob", "-666", "42",
-                             "0"),
-                             array('apple' => null, 'bob' => null),
-                             array());
+        $this->assertParseOk(
+            ["-a", "foo", "bar", "--apple", "ding", "dong",
+                "-b", "1", "2", "3", "--bob", "-666", "42",
+                "0"],
+            ['apple' => null, 'bob' => null],
+            []
+        );
     }
 }

--- a/test/Horde/Argv/CallbackMeddleArgsTest.php
+++ b/test/Horde/Argv/CallbackMeddleArgsTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Parser;
+
+use Horde_Argv_Parser;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Parser;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class CallbackMeddleArgsTest extends TestCase
@@ -17,13 +19,13 @@ class CallbackMeddleArgsTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $options = array();
+        $options = [];
         for ($i = -1; $i > -6; $i--) {
-            $options[] = $this->makeOption((string)$i, array('action' => 'callback',
-                                                             'callback' => array($this, 'process_n'),
-                                                             'dest' => 'things'));
+            $options[] = $this->makeOption((string) $i, ['action' => 'callback',
+                'callback' => [$this, 'process_n'],
+                'dest' => 'things']);
         }
-        $this->parser = new Horde_Argv_Parser(array('optionList' => $options));
+        $this->parser = new Horde_Argv_Parser(['optionList' => $options]);
     }
 
     /**
@@ -32,8 +34,8 @@ class CallbackMeddleArgsTest extends TestCase
     public function process_n($option, $opt, $value, $parser)
     {
         // option is -3, -5, etc.
-        $nargs = (int)substr($opt, 1);
-        $rargs =& $parser->rargs;
+        $nargs = (int) substr($opt, 1);
+        $rargs = & $parser->rargs;
         if (count($rargs) < $nargs) {
             $this->fail(sprintf("Expected %d arguments for %s option.", $nargs, $opt));
         }
@@ -44,16 +46,20 @@ class CallbackMeddleArgsTest extends TestCase
 
     public function testCallbackMeddleArgs()
     {
-        $this->assertParseOK(array("-1", "foo", "-3", "bar", "baz", "qux"),
-                             array('things' => array(array('foo'), array('bar', 'baz', 'qux'))),
-                             array(1, 3));
+        $this->assertParseOK(
+            ["-1", "foo", "-3", "bar", "baz", "qux"],
+            ['things' => [['foo'], ['bar', 'baz', 'qux']]],
+            [1, 3]
+        );
     }
 
     public function testCallbackMeddleArgsSeparator()
     {
-        $this->assertParseOK(array("-2", "foo", "--"),
-                             array('things' => array(array('foo', '--'))),
-                             array(2));
+        $this->assertParseOK(
+            ["-2", "foo", "--"],
+            ['things' => [['foo', '--']]],
+            [2]
+        );
     }
 
 }

--- a/test/Horde/Argv/CallbackTest.php
+++ b/test/Horde/Argv/CallbackTest.php
@@ -1,10 +1,11 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Option;
-use \Horde_Argv_Parser;
-use \Horde_Argv_IndentedHelpFormatter;
-use \Horde_Cli_Color;
+
+use Horde_Argv_Option;
+use Horde_Argv_Parser;
+use Horde_Argv_IndentedHelpFormatter;
+use Horde_Cli_Color;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -13,6 +14,7 @@ use \Horde_Cli_Color;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class CallbackTest extends TestCase
@@ -20,35 +22,41 @@ class CallbackTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $options = array(
-            new Horde_Argv_Option('-x', null,
-                array('action' => 'callback', 'callback' => array($this, 'processOpt'))),
-            new Horde_Argv_Option('-f', '--file',
-                array('action' => 'callback',
-                      'callback' => array($this, 'processOpt'),
-                      'type' => 'string',
-                      'dest' => 'filename')),
-        );
+        $options = [
+            new Horde_Argv_Option(
+                '-x',
+                null,
+                ['action' => 'callback', 'callback' => [$this, 'processOpt']]
+            ),
+            new Horde_Argv_Option(
+                '-f',
+                '--file',
+                ['action' => 'callback',
+                    'callback' => [$this, 'processOpt'],
+                    'type' => 'string',
+                    'dest' => 'filename']
+            ),
+        ];
 
-        $this->parser = new Horde_Argv_Parser(array('optionList' => $options));
+        $this->parser = new Horde_Argv_Parser(['optionList' => $options]);
     }
 
     public function processOpt($option, $opt, $value, $parser_)
     {
         if ($opt == '-x') {
-            $this->assertEquals(array('-x'), $option->shortOpts);
-            $this->assertEquals(array(), $option->longOpts);
+            $this->assertEquals(['-x'], $option->shortOpts);
+            $this->assertEquals([], $option->longOpts);
             $this->assertInstanceOf(get_class($this->parser), $parser_);
             $this->assertNull($value);
-            $this->assertEquals(array('filename' => null), iterator_to_array($parser_->values));
+            $this->assertEquals(['filename' => null], iterator_to_array($parser_->values));
 
             $parser_->values->x = 42;
-        } else if ($opt == '--file') {
-            $this->assertEquals(array('-f'), $option->shortOpts);
-            $this->assertEquals(array('--file'), $option->longOpts);
+        } elseif ($opt == '--file') {
+            $this->assertEquals(['-f'], $option->shortOpts);
+            $this->assertEquals(['--file'], $option->longOpts);
             $this->assertInstanceOf(get_class($this->parser), $parser_);
             $this->assertEquals('foo', $value);
-            $this->assertEquals(array('filename' => null, 'x' => 42), iterator_to_array($parser_->values));
+            $this->assertEquals(['filename' => null, 'x' => 42], iterator_to_array($parser_->values));
 
             $parser_->values->{$option->dest} = $value;
         } else {
@@ -58,9 +66,11 @@ class CallbackTest extends TestCase
 
     public function testCallback()
     {
-        $this->assertParseOk(array('-x', '--file=foo'),
-                             array('filename' => 'foo', 'x' => 42),
-                             array());
+        $this->assertParseOk(
+            ['-x', '--file=foo'],
+            ['filename' => 'foo', 'x' => 42],
+            []
+        );
     }
 
     public function testCallbackHelp()
@@ -68,29 +78,31 @@ class CallbackTest extends TestCase
         // This test was prompted by SF bug #960515 -- the point is not to
         // inspect the help text, just to make sure that formatHelp() doesn't
         // crash.
-        $parser = new Horde_Argv_Parser(array(
+        $parser = new Horde_Argv_Parser([
             'usage' => Horde_Argv_Option::SUPPRESS_USAGE,
             'formatter' => new Horde_Argv_IndentedHelpFormatter(
-                2, 24, null, true,
+                2,
+                24,
+                null,
+                true,
                 new Horde_Cli_Color(Horde_Cli_Color::FORMAT_NONE)
-            )
-        ));
+            ),
+        ]);
         $parser->removeOption('-h');
         $parser->addOption(
-            '-t', '--test',
-            array(
+            '-t',
+            '--test',
+            [
                 'action' => 'callback',
-                'callback' => array($this, 'returnNull'),
+                'callback' => [$this, 'returnNull'],
                 'type' => 'string',
-                'help' => 'foo'
-            )
+                'help' => 'foo',
+            ]
         );
 
         $expectedHelp = "Options:\n  -t TEST, --test=TEST  foo\n";
         $this->assertHelp($parser, $expectedHelp);
     }
 
-    public function returnNull()
-    {
-    }
+    public function returnNull() {}
 }

--- a/test/Horde/Argv/CallbackVarArgsTest.php
+++ b/test/Horde/Argv/CallbackVarArgsTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Option;
+
+use Horde_Argv_Option;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Option;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class CallbackVarArgsTest extends TestCase
@@ -17,25 +19,25 @@ class CallbackVarArgsTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $options = array(
-            $this->makeOption('-a', array('type' => 'int', 'nargs' => 2, 'dest' => 'a')),
-            $this->makeOption('-b', array('action' => 'store_true', 'dest' => 'b')),
-            $this->makeOption('-c', '--callback', array('action' => 'callback', 'callback' => array($this, 'variableArgs'), 'dest' => 'c')),
-        );
-        $this->parser = new InterceptingParser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE,
-                                                                'optionList' => $options));
+        $options = [
+            $this->makeOption('-a', ['type' => 'int', 'nargs' => 2, 'dest' => 'a']),
+            $this->makeOption('-b', ['action' => 'store_true', 'dest' => 'b']),
+            $this->makeOption('-c', '--callback', ['action' => 'callback', 'callback' => [$this, 'variableArgs'], 'dest' => 'c']),
+        ];
+        $this->parser = new InterceptingParser(['usage' => Horde_Argv_Option::SUPPRESS_USAGE,
+            'optionList' => $options]);
     }
 
     public function variableArgs($option, $opt, $value, $parser)
     {
         $this->assertNull($value);
         $done = 0;
-        $value = array();
-        $rargs =& $parser->rargs;
+        $value = [];
+        $rargs = & $parser->rargs;
         while ($rargs) {
             $arg = $rargs[0];
-            if ((substr($arg, 0, 2) == '--' && strlen($arg) > 2) ||
-                (substr($arg, 0, 1) == '-' && strlen($arg) > 1 && substr($arg, 1, 1) != '-')) {
+            if ((substr($arg, 0, 2) == '--' && strlen($arg) > 2)
+                || (substr($arg, 0, 1) == '-' && strlen($arg) > 1 && substr($arg, 1, 1) != '-')) {
                 break;
             } else {
                 $value[] = $arg;
@@ -47,35 +49,43 @@ class CallbackVarArgsTest extends TestCase
 
     public function testVariableArgs()
     {
-        $this->assertParseOK(array('-a3', '-5', '--callback', 'foo', 'bar'),
-                             array('a' => array(3, -5), 'b' => null, 'c' => array('foo', 'bar')),
-                             array());
+        $this->assertParseOK(
+            ['-a3', '-5', '--callback', 'foo', 'bar'],
+            ['a' => [3, -5], 'b' => null, 'c' => ['foo', 'bar']],
+            []
+        );
     }
 
     public function testConsumeSeparatorStopAtOption()
     {
-        $this->assertParseOK(array('-c', '37', '--', 'xxx', '-b', 'hello'),
-                             array('a' => null, 'b' => true, 'c' => array('37', '--', 'xxx')),
-                             array('hello'));
+        $this->assertParseOK(
+            ['-c', '37', '--', 'xxx', '-b', 'hello'],
+            ['a' => null, 'b' => true, 'c' => ['37', '--', 'xxx']],
+            ['hello']
+        );
     }
 
     public function testPositionalArgAndVariableArgs()
     {
-        $this->assertParseOK(array('hello', '-c', 'foo', '-', 'bar'),
-                             array('a' => null, 'b' => null, 'c' => array('foo', '-', 'bar')),
-                             array('hello'));
+        $this->assertParseOK(
+            ['hello', '-c', 'foo', '-', 'bar'],
+            ['a' => null, 'b' => null, 'c' => ['foo', '-', 'bar']],
+            ['hello']
+        );
     }
 
     public function testStopAtOption()
     {
-        $this->assertParseOK(array('-c', 'foo', '-b'),
-                             array('a' => null, 'b' => true, 'c' => array('foo')),
-                             array());
+        $this->assertParseOK(
+            ['-c', 'foo', '-b'],
+            ['a' => null, 'b' => true, 'c' => ['foo']],
+            []
+        );
     }
 
     public function testStopAtInvalidOption()
     {
-        $this->assertParseFail(array('-c', '3', '-5', '-a'), 'no such option: -5');
+        $this->assertParseFail(['-c', '3', '-5', '-a'], 'no such option: -5');
     }
 
 }

--- a/test/Horde/Argv/ChoiceTest.php
+++ b/test/Horde/Argv/ChoiceTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Option;
+
+use Horde_Argv_Option;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Option;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class ChoiceTest extends TestCase
@@ -17,28 +19,32 @@ class ChoiceTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->parser = new InterceptingParser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE));
-        $this->parser->addOption('-c', array('action' => 'store', 'type' => 'choice',
-                                 'dest' => 'choice', 'choices' => array('one', 'two', 'three')));
+        $this->parser = new InterceptingParser(['usage' => Horde_Argv_Option::SUPPRESS_USAGE]);
+        $this->parser->addOption('-c', ['action' => 'store', 'type' => 'choice',
+            'dest' => 'choice', 'choices' => ['one', 'two', 'three']]);
     }
 
     public function testValidChoice()
     {
-        $this->assertParseOk(array('-c', 'one', 'xyz'),
-                             array('choice' => 'one'),
-                             array('xyz'));
+        $this->assertParseOk(
+            ['-c', 'one', 'xyz'],
+            ['choice' => 'one'],
+            ['xyz']
+        );
     }
 
     public function testInvalidChoice()
     {
-        $this->assertParseFail(array('-c', 'four', 'abc'),
-                               "option -c: invalid choice: 'four' " .
-                               "(choose from 'one', 'two', 'three')");
+        $this->assertParseFail(
+            ['-c', 'four', 'abc'],
+            "option -c: invalid choice: 'four' "
+                               . "(choose from 'one', 'two', 'three')"
+        );
     }
 
     public function testAddChoiceOption()
     {
-        $this->parser->addOption('-d', '--default', array('choices' => array('four', 'five', 'six')));
+        $this->parser->addOption('-d', '--default', ['choices' => ['four', 'five', 'six']]);
         $opt = $this->parser->getOption('-d');
         $this->assertEquals('choice', $opt->type);
         $this->assertEquals('store', $opt->action);

--- a/test/Horde/Argv/ConflictOverrideTest.php
+++ b/test/Horde/Argv/ConflictOverrideTest.php
@@ -1,9 +1,10 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Option;
-use \Horde_Argv_IndentedHelpFormatter;
-use \Horde_Cli_Color;
+
+use Horde_Argv_Option;
+use Horde_Argv_IndentedHelpFormatter;
+use Horde_Cli_Color;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -12,6 +13,7 @@ use \Horde_Cli_Color;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class ConflictOverrideTest extends TestCase
@@ -19,30 +21,35 @@ class ConflictOverrideTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->parser = new InterceptingParser(array(
+        $this->parser = new InterceptingParser([
             'usage' => Horde_Argv_Option::SUPPRESS_USAGE,
             'formatter' => new Horde_Argv_IndentedHelpFormatter(
-                2, 24, null, true,
+                2,
+                24,
+                null,
+                true,
                 new Horde_Cli_Color(Horde_Cli_Color::FORMAT_NONE)
-            )
-        ));
+            ),
+        ]);
         $this->parser->setConflictHandler('resolve');
         $this->parser->addOption(
-            '-n', '--dry-run',
-            array(
+            '-n',
+            '--dry-run',
+            [
                 'action' => 'store_true',
                 'dest' => 'dry_run',
-                'help' => "don't do anything"
-            )
+                'help' => "don't do anything",
+            ]
         );
         $this->parser->addOption(
-            '--dry-run', '-n',
-            array(
+            '--dry-run',
+            '-n',
+            [
                 'action' => 'store_const',
                 'const' => 42,
                 'dest' => 'dry_run',
-                'help' => 'dry run mode'
-            )
+                'help' => 'dry run mode',
+            ]
         );
     }
 
@@ -50,8 +57,8 @@ class ConflictOverrideTest extends TestCase
     {
         $opt = $this->parser->getOption('--dry-run');
 
-        $this->assertEquals(array('-n'), $opt->shortOpts);
-        $this->assertEquals(array('--dry-run'), $opt->longOpts);
+        $this->assertEquals(['-n'], $opt->shortOpts);
+        $this->assertEquals(['--dry-run'], $opt->longOpts);
     }
 
     public function testConflictOverrideHelp()
@@ -59,13 +66,15 @@ class ConflictOverrideTest extends TestCase
         $output = "Options:\n"
                 . "  -h, --help     show this help message and exit\n"
                 . "  -n, --dry-run  dry run mode\n";
-        $this->assertOutput(array('-h'), $output);
+        $this->assertOutput(['-h'], $output);
     }
 
     public function testConflictOverrideArgs()
     {
-        $this->assertParseOk(array('-n'),
-                             array('dry_run' => 42),
-                             array());
+        $this->assertParseOk(
+            ['-n'],
+            ['dry_run' => 42],
+            []
+        );
     }
 }

--- a/test/Horde/Argv/ConflictResolveTest.php
+++ b/test/Horde/Argv/ConflictResolveTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_IndentedHelpFormatter;
+
+use Horde_Argv_IndentedHelpFormatter;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_IndentedHelpFormatter;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class ConflictResolveTest extends ConflictTestCase
@@ -18,9 +20,9 @@ class ConflictResolveTest extends ConflictTestCase
     {
         parent::setUp();
         $this->parser->setConflictHandler('resolve');
-        $this->parser->addOption('-v', '--version', array('action' => 'callback',
-                                                          'callback' => array($this, 'showVersion'),
-                                                          'help' => 'show version'));
+        $this->parser->addOption('-v', '--version', ['action' => 'callback',
+            'callback' => [$this, 'showVersion'],
+            'help' => 'show version']);
     }
 
     public function testConflictResolve()
@@ -32,11 +34,11 @@ class ConflictResolveTest extends ConflictTestCase
         $this->assertSame($vOpt, $versionOpt);
         $this->assertNotSame($vOpt, $verboseOpt);
 
-        $this->assertEquals(array('--version'), $vOpt->longOpts);
-        $this->assertEquals(array('-v'), $versionOpt->shortOpts);
-        $this->assertEquals(array('--version'), $versionOpt->longOpts);
-        $this->assertEquals(array(), $verboseOpt->shortOpts);
-        $this->assertEquals(array('--verbose'), $verboseOpt->longOpts);
+        $this->assertEquals(['--version'], $vOpt->longOpts);
+        $this->assertEquals(['-v'], $versionOpt->shortOpts);
+        $this->assertEquals(['--version'], $versionOpt->longOpts);
+        $this->assertEquals([], $verboseOpt->shortOpts);
+        $this->assertEquals(['--verbose'], $verboseOpt->longOpts);
     }
 
     public function testConflictResolveHelp()
@@ -46,27 +48,33 @@ class ConflictResolveTest extends ConflictTestCase
                 . "  -h, --help     show this help message and exit\n"
                 . "  -v, --version  show version\n";
 
-        $this->assertOutput(array('-h'), $output);
+        $this->assertOutput(['-h'], $output);
     }
 
     public function testConflictResolveShortOpt()
     {
-        $this->assertParseOk(array('-v'),
-                             array('verbose' => null, 'showVersion' => 1),
-                             array());
+        $this->assertParseOk(
+            ['-v'],
+            ['verbose' => null, 'showVersion' => 1],
+            []
+        );
     }
 
     public function testConflictResolveLongOpt()
     {
-        $this->assertParseOk(array('--verbose'),
-                             array('verbose' => 1),
-                             array());
+        $this->assertParseOk(
+            ['--verbose'],
+            ['verbose' => 1],
+            []
+        );
     }
 
     public function testConflictResolveLongOpts()
     {
-        $this->assertParseOk(array('--verbose', '--version'),
-                             array('verbose' => 1, 'showVersion' => 1),
-                             array());
+        $this->assertParseOk(
+            ['--verbose', '--version'],
+            ['verbose' => 1, 'showVersion' => 1],
+            []
+        );
     }
 }

--- a/test/Horde/Argv/ConflictTest.php
+++ b/test/Horde/Argv/ConflictTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_OptionGroup;
+
+use Horde_Argv_OptionGroup;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_OptionGroup;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class ConflictTest extends ConflictTestCase
@@ -17,14 +19,16 @@ class ConflictTest extends ConflictTestCase
     public function assertConflictError($func)
     {
         try {
-            call_user_func($func, '-v', '--version', array(
+            call_user_func($func, '-v', '--version', [
                 'action'   => 'callback',
-                'callback' => array($this, 'showVersion'),
-                'help'     => 'show version'));
+                'callback' => [$this, 'showVersion'],
+                'help'     => 'show version']);
             $this->fail();
         } catch (Horde_Argv_OptionConflictException $e) {
-            $this->assertEquals("option -v/--version: conflicting option string(s): -v",
-                                $e->getMessage());
+            $this->assertEquals(
+                "option -v/--version: conflicting option string(s): -v",
+                $e->getMessage()
+            );
             $this->assertEquals('-v/--version', $e->optionId);
         }
     }
@@ -32,20 +36,20 @@ class ConflictTest extends ConflictTestCase
     public function testConflictError()
     {
         $this->expectException('Horde_Argv_OptionConflictException');
-        $this->assertConflictError(array($this->parser, 'addOption'));
+        $this->assertConflictError([$this->parser, 'addOption']);
     }
 
     public function testConflictErrorGroup()
     {
         $this->expectException('Horde_Argv_OptionConflictException');
         $group = new Horde_Argv_OptionGroup($this->parser, 'Group 1');
-        $this->assertConflictError(array($group, 'addOption'));
+        $this->assertConflictError([$group, 'addOption']);
     }
 
     public function testNoSuchConflictHandler()
     {
         $this->expectException('InvalidArgumentException');
-        $this->assertRaises(array($this->parser, 'setConflictHandler'), array('foo'), 'InvalidArgumentException', "invalid conflictHandler 'foo'");
+        $this->assertRaises([$this->parser, 'setConflictHandler'], ['foo'], 'InvalidArgumentException', "invalid conflictHandler 'foo'");
     }
 
 }

--- a/test/Horde/Argv/ConflictTestCase.php
+++ b/test/Horde/Argv/ConflictTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
  * @author     Mike Naberezny <mike@maintainable.com>
@@ -7,30 +8,38 @@
  * @package    Argv
  * @subpackage UnitTests
  */
-namespace Horde\Argv;
-use \Horde_Argv_Parser;
-use \Horde_Argv_Option;
-use \Horde_Argv_IndentedHelpFormatter;
-use \Horde_Cli_Color;
 
+namespace Horde\Argv;
+
+use Horde_Argv_Parser;
+use Horde_Argv_Option;
+use Horde_Argv_IndentedHelpFormatter;
+use Horde_Cli_Color;
+
+/**
+ * @coversNothing
+ */
 class ConflictTestCase extends TestCase
 {
     public function setUp(): void
     {
-        $options = array(new Horde_Argv_Option('-v', '--verbose', array(
+        $options = [new Horde_Argv_Option('-v', '--verbose', [
             'action' => 'count',
             'dest' => 'verbose',
-            'help' => 'increment verbosity'))
-        );
+            'help' => 'increment verbosity']),
+        ];
 
-        $this->parser = new InterceptingParser(array(
+        $this->parser = new InterceptingParser([
             'usage' => Horde_Argv_Option::SUPPRESS_USAGE,
             'optionList' => $options,
             'formatter' => new Horde_Argv_IndentedHelpFormatter(
-                2, 24, null, true,
+                2,
+                24,
+                null,
+                true,
                 new Horde_Cli_Color(Horde_Cli_Color::FORMAT_NONE)
-            )
-        ));
+            ),
+        ]);
     }
 
     public function showVersion($option, $opt, $value, $parser)

--- a/test/Horde/Argv/ConflictingDefaultsTest.php
+++ b/test/Horde/Argv/ConflictingDefaultsTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Parser;
+
+use Horde_Argv_Parser;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -14,32 +15,33 @@ use \Horde_Argv_Parser;
 
 /**
  * Conflicting default values: the last one should win.
+ * @coversNothing
  */
 class ConflictingDefaultsTest extends TestCase
 {
     public function setUp(): void
     {
         parent::setUp();
-        $options = array(
-            $this->makeOption('-v', array('action' => 'store_true', 'dest' => 'verbose', 'default' => 1))
-        );
+        $options = [
+            $this->makeOption('-v', ['action' => 'store_true', 'dest' => 'verbose', 'default' => 1]),
+        ];
 
-        $this->parser = new Horde_Argv_Parser(array('optionList' => $options));
+        $this->parser = new Horde_Argv_Parser(['optionList' => $options]);
     }
 
     public function testConflictDefault()
     {
-        $this->parser->addOption('-q', array('action' => 'store_false', 'dest' => 'verbose',
-                                             'default' => 0));
+        $this->parser->addOption('-q', ['action' => 'store_false', 'dest' => 'verbose',
+            'default' => 0]);
 
-        $this->assertParseOk(array(), array('verbose' => 0), array());
+        $this->assertParseOk([], ['verbose' => 0], []);
     }
 
     public function testConflictDefaultNone()
     {
-        $this->parser->addOption('-q', array('action' => 'store_false', 'dest' => 'verbose',
-                                             'default' => null));
+        $this->parser->addOption('-q', ['action' => 'store_false', 'dest' => 'verbose',
+            'default' => null]);
 
-        $this->assertParseOk(array(), array('verbose' => null), array());
+        $this->assertParseOk([], ['verbose' => null], []);
     }
 }

--- a/test/Horde/Argv/CountTest.php
+++ b/test/Horde/Argv/CountTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Option;
+
+use Horde_Argv_Option;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Option;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class CountTest extends TestCase
@@ -18,86 +20,101 @@ class CountTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->parser = new InterceptingParser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE));
-        $this->vOpt = $this->makeOption('-v', array('action' => 'count', 'dest' => 'verbose'));
+        $this->parser = new InterceptingParser(['usage' => Horde_Argv_Option::SUPPRESS_USAGE]);
+        $this->vOpt = $this->makeOption('-v', ['action' => 'count', 'dest' => 'verbose']);
         $this->parser->addOption($this->vOpt);
-        $this->parser->addOption('--verbose', array('type' => 'int', 'dest' => 'verbose'));
-        $this->parser->addOption('-q', '--quiet',
-                                 array('action' => 'store_const', 'dest' => 'verbose', 'const' => 0));
+        $this->parser->addOption('--verbose', ['type' => 'int', 'dest' => 'verbose']);
+        $this->parser->addOption(
+            '-q',
+            '--quiet',
+            ['action' => 'store_const', 'dest' => 'verbose', 'const' => 0]
+        );
     }
 
     public function testEmpty()
     {
-        $this->assertParseOk(array(), array('verbose' => null), array());
+        $this->assertParseOk([], ['verbose' => null], []);
     }
 
     public function testCountOne()
     {
-        $this->assertParseOk(array('-v'), array('verbose' => 1), array());
+        $this->assertParseOk(['-v'], ['verbose' => 1], []);
     }
 
     public function testCountThree()
     {
-        $this->assertParseOk(array('-vvv'), array('verbose' => 3), array());
+        $this->assertParseOk(['-vvv'], ['verbose' => 3], []);
     }
 
     public function testCountThreeApart()
     {
-        $this->assertParseOk(array('-v', '-v', '-v'), array('verbose' => 3), array());
+        $this->assertParseOk(['-v', '-v', '-v'], ['verbose' => 3], []);
     }
 
     public function testCountOverrideAmount()
     {
-        $this->assertParseOk(array('-vvv', '--verbose=2'), array('verbose' => 2), array());
+        $this->assertParseOk(['-vvv', '--verbose=2'], ['verbose' => 2], []);
     }
 
     public function testCountOverrideQuiet()
     {
-        $this->assertParseOk(array('-vvv', '--verbose=2', '-q'), array('verbose' => 0), array());
+        $this->assertParseOk(['-vvv', '--verbose=2', '-q'], ['verbose' => 0], []);
     }
 
     public function testCountOverriding()
     {
-        $this->assertParseOk(array('-vvv', '--verbose=2', '-q', '-v'),
-                             array('verbose' => 1), array());
+        $this->assertParseOk(
+            ['-vvv', '--verbose=2', '-q', '-v'],
+            ['verbose' => 1],
+            []
+        );
     }
 
     public function testCountInterspersedArgs()
     {
-        $this->assertParseOk(array('--quiet', '3', '-v'),
-                             array('verbose' => 1),
-                             array('3'));
+        $this->assertParseOk(
+            ['--quiet', '3', '-v'],
+            ['verbose' => 1],
+            ['3']
+        );
     }
 
     public function testCountNoInterspersedArgs()
     {
         $this->parser->disableInterspersedArgs();
-        $this->assertParseOk(array('--quiet', '3', '-v'),
-                             array('verbose' => 0),
-                             array('3', '-v'));
+        $this->assertParseOk(
+            ['--quiet', '3', '-v'],
+            ['verbose' => 0],
+            ['3', '-v']
+        );
     }
 
     public function testCountNoSuchOption()
     {
-        $this->assertParseFail(array('-q3', '-v'), 'no such option: -3');
+        $this->assertParseFail(['-q3', '-v'], 'no such option: -3');
     }
 
     public function testCountOptionNoValue()
     {
-        $this->assertParseFail(array('--quiet=3', 'v'),
-                               '--quiet option does not take a value');
+        $this->assertParseFail(
+            ['--quiet=3', 'v'],
+            '--quiet option does not take a value'
+        );
     }
 
     public function testCountWithDefault()
     {
         $this->parser->setDefault('verbose', 0);
-        $this->assertParseOk(array(), array('verbose' => 0), array());
+        $this->assertParseOk([], ['verbose' => 0], []);
     }
 
     public function testCountOverridingDefault()
     {
         $this->parser->setDefault('verbose', 0);
-        $this->assertParseOk(array('-vvv', '--verbose=2', '-q', '-v'),
-                             array('verbose' => 1), array());
+        $this->assertParseOk(
+            ['-vvv', '--verbose=2', '-q', '-v'],
+            ['verbose' => 1],
+            []
+        );
     }
 }

--- a/test/Horde/Argv/DefaultValuesTest.php
+++ b/test/Horde/Argv/DefaultValuesTest.php
@@ -1,8 +1,9 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Option;
-use \Horde_Argv_Parser;
+
+use Horde_Argv_Option;
+use Horde_Argv_Parser;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -11,30 +12,31 @@ use \Horde_Argv_Parser;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class DefaultValuesTest extends TestCase
 {
     public $expected;
-    
+
     public function setUp(): void
     {
         parent::setUp();
         $this->parser = new Horde_Argv_Parser();
-        $this->parser->addOption('-v', '--verbose', array('default' => true));
-        $this->parser->addOption('-q', '--quiet', array('dest' => 'verbose'));
-        $this->parser->addOption('-n', array('type' => 'int', 'default' => 37));
-        $this->parser->addOption('-m', array('type' => 'int'));
-        $this->parser->addOption('-s', array('default' => 'foo'));
+        $this->parser->addOption('-v', '--verbose', ['default' => true]);
+        $this->parser->addOption('-q', '--quiet', ['dest' => 'verbose']);
+        $this->parser->addOption('-n', ['type' => 'int', 'default' => 37]);
+        $this->parser->addOption('-m', ['type' => 'int']);
+        $this->parser->addOption('-s', ['default' => 'foo']);
         $this->parser->addOption('-t');
-        $this->parser->addOption('-u', array('default' => null));
+        $this->parser->addOption('-u', ['default' => null]);
 
-        $this->expected = array('verbose' => true,
-                                'n' => 37,
-                                'm' => null,
-                                's' => 'foo',
-                                't' => null,
-                                'u' => null);
+        $this->expected = ['verbose' => true,
+            'n' => 37,
+            'm' => null,
+            's' => 'foo',
+            't' => null,
+            'u' => null];
     }
 
     public function testBasicDefault()
@@ -44,64 +46,67 @@ class DefaultValuesTest extends TestCase
 
     public function testMixedDefaultsPost()
     {
-        $this->parser->setDefaults(array('n' => 42, 'm' => -100));
-        $this->expected = array_merge($this->expected, array('n' => 42, 'm' => -100));
+        $this->parser->setDefaults(['n' => 42, 'm' => -100]);
+        $this->expected = array_merge($this->expected, ['n' => 42, 'm' => -100]);
         $this->assertEquals($this->expected, iterator_to_array($this->parser->getDefaultValues()));
     }
 
     public function testMixedDefaultsPre()
     {
-        $this->parser->setDefaults(array('x' => 'barf', 'y' => 'blah'));
-        $this->parser->addOption('-x', array('default' => 'frob'));
+        $this->parser->setDefaults(['x' => 'barf', 'y' => 'blah']);
+        $this->parser->addOption('-x', ['default' => 'frob']);
         $this->parser->addOption('-y');
 
-        $this->expected = array_merge($this->expected, array('x' => 'frob', 'y' => 'blah'));
+        $this->expected = array_merge($this->expected, ['x' => 'frob', 'y' => 'blah']);
         $this->assertEquals($this->expected, iterator_to_array($this->parser->getDefaultValues()));
 
         $this->parser->removeOption('-y');
-        $this->parser->addOption('-y', array('default' => null));
-        $this->expected = array_merge($this->expected, array('y' => null));
+        $this->parser->addOption('-y', ['default' => null]);
+        $this->expected = array_merge($this->expected, ['y' => null]);
         $this->assertEquals($this->expected, iterator_to_array($this->parser->getDefaultValues()));
     }
 
     public function testProcessDefault()
     {
-        $this->expectException('ReflectionException');    
+        $this->expectException('ReflectionException');
 
         $this->parser->optionClass = 'Horde_Argv_DurationOption';
-        $this->parser->addOption('-d', array('type' => 'duration', 'default' => 300));
-        $this->parser->addOption('-e', array('type' => 'duration', 'default' => '6m'));
-        $this->parser->setDefaults(array('n' => '42'));
+        $this->parser->addOption('-d', ['type' => 'duration', 'default' => 300]);
+        $this->parser->addOption('-e', ['type' => 'duration', 'default' => '6m']);
+        $this->parser->setDefaults(['n' => '42']);
 
-        $this->expected = array_merge($this->expected, array('d' => 300, 'e' => 360, 'n' => '42'));
+        $this->expected = array_merge($this->expected, ['d' => 300, 'e' => 360, 'n' => '42']);
     }
 }
 
 class Horde_Argv_DurationOption extends Horde_Argv_Option
 {
-    public $TYPES = array('string', 'int', 'long', 'float', 'complex', 'choice', 'duration');
+    public $TYPES = ['string', 'int', 'long', 'float', 'complex', 'choice', 'duration'];
 
-    public $TYPE_CHECKER = array('int'    => 'checkBuiltin',
-                                 'long'   => 'checkBuiltin',
-                                 'float'  => 'checkBuiltin',
-                                 'complex'=> 'checkBuiltin',
-                                 'choice' => 'checkChoice',
-                                 'duration' => 'checkDuration',
-    );
+    public $TYPE_CHECKER = ['int'    => 'checkBuiltin',
+        'long'   => 'checkBuiltin',
+        'float'  => 'checkBuiltin',
+        'complex' => 'checkBuiltin',
+        'choice' => 'checkChoice',
+        'duration' => 'checkDuration',
+    ];
 
     public function checkDuration($opt, $value)
     {
         // Custom type for testing processing of default values.
-        $time_units = array('s' => 1, 'm' => 60, 'h' => 60 * 60, 'd' => 60 * 60 * 24);
+        $time_units = ['s' => 1, 'm' => 60, 'h' => 60 * 60, 'd' => 60 * 60 * 24];
 
         $last = substr($value, -1);
         if (is_numeric($last)) {
-            return (int)$value;
+            return (int) $value;
         } elseif (isset($time_units[$last])) {
-            return (int)substr($value, 0, -1) * $time_units[$last];
+            return (int) substr($value, 0, -1) * $time_units[$last];
         } else {
             throw new Horde_Argv_OptionValueException(sprintf(
-                'option %s: invalid duration: %s', $opt, $value));
+                'option %s: invalid duration: %s',
+                $opt,
+                $value
+            ));
         }
     }
 

--- a/test/Horde/Argv/ExpandDefaultsTest.php
+++ b/test/Horde/Argv/ExpandDefaultsTest.php
@@ -1,9 +1,10 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Parser;
-use \Horde_Argv_IndentedHelpFormatter;
-use \Horde_Cli_Color;
+
+use Horde_Argv_Parser;
+use Horde_Argv_IndentedHelpFormatter;
+use Horde_Cli_Color;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -12,6 +13,7 @@ use \Horde_Cli_Color;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class ExpandDefaultsTest extends TestCase
@@ -21,102 +23,128 @@ class ExpandDefaultsTest extends TestCase
     public $expected_help_none;
     public $help_prefix;
     public $default_tag;
-    
+
     public function setUp(): void
     {
         parent::setUp();
-        $this->parser = new Horde_Argv_Parser(array(
+        $this->parser = new Horde_Argv_Parser([
             'prog' => 'test',
             'formatter' => new Horde_Argv_IndentedHelpFormatter(
-                2, 24, null, true,
+                2,
+                24,
+                null,
+                true,
                 new Horde_Cli_Color(Horde_Cli_Color::FORMAT_NONE)
-            )
-        ));
+            ),
+        ]);
         $this->help_prefix = 'Usage: test [options]
 
 Options:
   -h, --help            show this help message and exit';
 
         $this->file_help = "read from FILE [default: %default]";
-        $this->expected_help_file = $this->help_prefix . "\n" .
-            "  -f FILE, --file=FILE  read from FILE [default: foo.txt]\n";
-        $this->expected_help_none = $this->help_prefix . "\n" .
-            "  -f FILE, --file=FILE  read from FILE [default: none]\n";
+        $this->expected_help_file = $this->help_prefix . "\n"
+            . "  -f FILE, --file=FILE  read from FILE [default: foo.txt]\n";
+        $this->expected_help_none = $this->help_prefix . "\n"
+            . "  -f FILE, --file=FILE  read from FILE [default: none]\n";
     }
 
     public function testOptionDefault()
     {
-        $this->parser->addOption("-f", "--file", array('default' => 'foo.txt', 'help' => $this->file_help));
+        $this->parser->addOption("-f", "--file", ['default' => 'foo.txt', 'help' => $this->file_help]);
         $this->assertHelp($this->parser, $this->expected_help_file);
     }
 
     public function testParserDefault1()
     {
-        $this->parser->addOption("-f", "--file",
-                                 array('help' => $this->file_help));
+        $this->parser->addOption(
+            "-f",
+            "--file",
+            ['help' => $this->file_help]
+        );
         $this->parser->setDefault('file', "foo.txt");
         $this->assertHelp($this->parser, $this->expected_help_file);
     }
 
     public function testParserDefault2()
     {
-        $this->parser->addOption("-f", "--file",
-                                 array('help' => $this->file_help));
-        $this->parser->setDefaults(array('file' => 'foo.txt'));
+        $this->parser->addOption(
+            "-f",
+            "--file",
+            ['help' => $this->file_help]
+        );
+        $this->parser->setDefaults(['file' => 'foo.txt']);
         $this->assertHelp($this->parser, $this->expected_help_file);
     }
 
     public function testNoDefault()
     {
-        $this->parser->addOption("-f", "--file",
-                                 array('help' => $this->file_help));
+        $this->parser->addOption(
+            "-f",
+            "--file",
+            ['help' => $this->file_help]
+        );
         $this->assertHelp($this->parser, $this->expected_help_none);
     }
 
     public function testDefaultNone1()
     {
-        $this->parser->addOption("-f", "--file",
-                                 array('default' => null,
-                                       'help' => $this->file_help));
+        $this->parser->addOption(
+            "-f",
+            "--file",
+            ['default' => null,
+                'help' => $this->file_help]
+        );
         $this->assertHelp($this->parser, $this->expected_help_none);
     }
 
     public function testDefaultNone2()
     {
-        $this->parser->addOption("-f", "--file",
-                                 array('help' => $this->file_help));
-        $this->parser->setDefaults(array('file' => null));
+        $this->parser->addOption(
+            "-f",
+            "--file",
+            ['help' => $this->file_help]
+        );
+        $this->parser->setDefaults(['file' => null]);
         $this->assertHelp($this->parser, $this->expected_help_none);
     }
 
     public function testFloatDefault()
     {
         $this->parser->addOption(
-            "-p", "--prob",
-            array('help' => "blow up with probability PROB [default: %default]"));
-        $this->parser->setDefaults(array('prob' => 0.43));
-        $expected_help = $this->help_prefix . "\n" .
-            "  -p PROB, --prob=PROB  blow up with probability PROB [default: 0.43]\n";
+            "-p",
+            "--prob",
+            ['help' => "blow up with probability PROB [default: %default]"]
+        );
+        $this->parser->setDefaults(['prob' => 0.43]);
+        $expected_help = $this->help_prefix . "\n"
+            . "  -p PROB, --prob=PROB  blow up with probability PROB [default: 0.43]\n";
         $this->assertHelp($this->parser, $expected_help);
     }
 
     public function testAltExpand()
     {
-        $this->parser->addOption("-f", "--file",
-                                 array('default' => "foo.txt",
-                                       'help' => "read from FILE [default: *DEFAULT*]"));
+        $this->parser->addOption(
+            "-f",
+            "--file",
+            ['default' => "foo.txt",
+                'help' => "read from FILE [default: *DEFAULT*]"]
+        );
         $this->parser->formatter->default_tag = "*DEFAULT*";
         $this->assertHelp($this->parser, $this->expected_help_file);
     }
 
     public function testNoExpand()
     {
-        $this->parser->addOption("-f", "--file",
-                                 array('default' => "foo.txt",
-                                       'help' => "read from %default file"));
+        $this->parser->addOption(
+            "-f",
+            "--file",
+            ['default' => "foo.txt",
+                'help' => "read from %default file"]
+        );
         $this->parser->formatter->default_tag = null;
-        $expected_help = $this->help_prefix . "\n" .
-            "  -f FILE, --file=FILE  read from %default file\n";
+        $expected_help = $this->help_prefix . "\n"
+            . "  -f FILE, --file=FILE  read from %default file\n";
         $this->assertHelp($this->parser, $expected_help);
     }
 

--- a/test/Horde/Argv/ExtendAddActionsTest.php
+++ b/test/Horde/Argv/ExtendAddActionsTest.php
@@ -1,8 +1,9 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Option;
-use \Horde_Argv_Parser;
+
+use Horde_Argv_Option;
+use Horde_Argv_Parser;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -11,6 +12,7 @@ use \Horde_Argv_Parser;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class ExtendAddActionsTest extends TestCase
@@ -18,63 +20,67 @@ class ExtendAddActionsTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $options = array(new Horde_Argv_ExtendAddActionsTest_MyOption("-a", "--apple", array(
-            'action' => "extend", 'type' => "string", 'dest' => "apple")));
-        $this->parser = new Horde_Argv_Parser(array('optionList' => $options));
+        $options = [new Horde_Argv_ExtendAddActionsTest_MyOption("-a", "--apple", [
+            'action' => "extend", 'type' => "string", 'dest' => "apple"])];
+        $this->parser = new Horde_Argv_Parser(['optionList' => $options]);
     }
 
     public function testExtendAddAction()
     {
-        $this->assertParseOK(array("-afoo,bar", "--apple=blah"),
-                             array('apple' => array("foo", "bar", "blah")),
-                             array());
+        $this->assertParseOK(
+            ["-afoo,bar", "--apple=blah"],
+            ['apple' => ["foo", "bar", "blah"]],
+            []
+        );
     }
 
     public function testExtendAddActionNormal()
     {
-        $this->assertParseOK(array("-a", "foo", "-abar", "--apple=x,y"),
-                             array('apple' => array("foo", "bar", "x", "y")),
-                             array());
+        $this->assertParseOK(
+            ["-a", "foo", "-abar", "--apple=x,y"],
+            ['apple' => ["foo", "bar", "x", "y"]],
+            []
+        );
     }
 
 }
 
 class Horde_Argv_ExtendAddActionsTest_MyOption extends Horde_Argv_Option
 {
-    public $ACTIONS = array("store",
-                            "store_const",
-                            "store_true",
-                            "store_false",
-                            "append",
-                            "append_const",
-                            "count",
-                            "callback",
-                            "help",
-                            "version",
-                            "extend",
-                            );
+    public $ACTIONS = ["store",
+        "store_const",
+        "store_true",
+        "store_false",
+        "append",
+        "append_const",
+        "count",
+        "callback",
+        "help",
+        "version",
+        "extend",
+    ];
 
-    public $STORE_ACTIONS = array("store",
-                     "store_const",
-                     "store_true",
-                     "store_false",
-                     "append",
-                     "append_const",
-                     "count",
-                     "extend",
-                                  );
+    public $STORE_ACTIONS = ["store",
+        "store_const",
+        "store_true",
+        "store_false",
+        "append",
+        "append_const",
+        "count",
+        "extend",
+    ];
 
-    public $TYPED_ACTIONS = array("store",
-                                  "append",
-                                  "callback",
-                                  "extend",
-                                  );
+    public $TYPED_ACTIONS = ["store",
+        "append",
+        "callback",
+        "extend",
+    ];
 
     public function takeAction($action, $dest, $opt, $value, $values, $parser)
     {
         if ($action == "extend") {
             $lvalue = explode(',', $value);
-            $values->$dest = array_merge($values->ensureValue($dest, array()), $lvalue);
+            $values->$dest = array_merge($values->ensureValue($dest, []), $lvalue);
         } else {
             parent::takeAction($action, $dest, $opt, $parser, $value, $values);
         }

--- a/test/Horde/Argv/ExtendAddTypesTest.php
+++ b/test/Horde/Argv/ExtendAddTypesTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Option;
+
+use Horde_Argv_Option;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Option;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class ExtendAddTypesTest extends TestCase
@@ -20,10 +22,10 @@ class ExtendAddTypesTest extends TestCase
     {
         parent::setUp();
         if (class_exists('Horde\\Argv\\ExtendAddTypesTest\\MyOption')) {
-            $this->parser = new InterceptingParser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE,
-                                                                    'optionClass' => 'Horde\\Argv\\ExtendAddTypesTest\\MyOption'));
-            $this->parser->addOption("-a", null, array('type' => "string", 'dest' => "a"));
-            $this->parser->addOption("-f", "--file", array('type' => "file", 'dest' => "file"));
+            $this->parser = new InterceptingParser(['usage' => Horde_Argv_Option::SUPPRESS_USAGE,
+                'optionClass' => 'Horde\\Argv\\ExtendAddTypesTest\\MyOption']);
+            $this->parser->addOption("-a", null, ['type' => "string", 'dest' => "a"]);
+            $this->parser->addOption("-f", "--file", ['type' => "file", 'dest' => "file"]);
         }
 
         /* @todo make more system independent */
@@ -43,9 +45,11 @@ class ExtendAddTypesTest extends TestCase
     {
         if (class_exists('Horde\\Argv\\ExtendAddTypesTest\\MyOption')) {
             touch($this->testPath);
-            $this->assertParseOK(array("--file", $this->testPath, "-afoo"),
-                                array('file' => $this->testPath, 'a' => 'foo'),
-                                array());
+            $this->assertParseOK(
+                ["--file", $this->testPath, "-afoo"],
+                ['file' => $this->testPath, 'a' => 'foo'],
+                []
+            );
         } else {
             $this->markTestSkipped('Class Horde_Argv_ExtendAddTypesTest_MyOption doesnt exist.');
         }
@@ -56,8 +60,10 @@ class ExtendAddTypesTest extends TestCase
     {
         if (class_exists('Horde\\Argv\\ExtendAddTypesTest\\MyOption')) {
             unlink($this->testPath);
-            $this->assertParseFail(array("--file", $this->testPath, "-afoo"),
-                               sprintf("%s: file does not exist", $this->testPath));
+            $this->assertParseFail(
+                ["--file", $this->testPath, "-afoo"],
+                sprintf("%s: file does not exist", $this->testPath)
+            );
         } else {
             $this->markTestSkipped('Class Horde_Argv_ExtendAddTypesTest_MyOption doesnt exist.');
         }
@@ -68,8 +74,10 @@ class ExtendAddTypesTest extends TestCase
         if (class_exists('Horde\\Argv\\ExtendAddTypesTest\\MyOption')) {
             unlink($this->testPath);
             mkdir($this->testPath);
-            $this->assertParseFail(array("--file", $this->testPath, "-afoo"),
-                               sprintf("%s: not a regular file", $this->testPath));
+            $this->assertParseFail(
+                ["--file", $this->testPath, "-afoo"],
+                sprintf("%s: not a regular file", $this->testPath)
+            );
         } else {
             $this->markTestSkipped('Class Horde_Argv_ExtendAddTypesTest_MyOption doesnt exist.');
         }

--- a/test/Horde/Argv/ExtendAddTypesTest/MyOption.php
+++ b/test/Horde/Argv/ExtendAddTypesTest/MyOption.php
@@ -2,29 +2,29 @@
 
 namespace Horde\Argv\ExtendAddTypesTest;
 
-use \Horde_Argv_Option;
+use Horde_Argv_Option;
+use Horde_Argv_OptionValueException;
 
 class MyOption extends Horde_Argv_Option
 {
-    public $TYPES = array('string', 'int', 'long', 'float', 'complex', 'choice', 'file');
+    public $TYPES = ['string', 'int', 'long', 'float', 'complex', 'choice', 'file'];
 
-    public $TYPE_CHECKER = array("int"    => 'checkBuiltin',
-                     "long"   => 'checkBuiltin',
-                     "float"  => 'checkBuiltin',
-                     "complex"=> 'checkBuiltin',
-                     "choice" => 'checkChoice',
-                     'file' => 'checkFile',
-    );
+    public $TYPE_CHECKER = ["int"    => 'checkBuiltin',
+        "long"   => 'checkBuiltin',
+        "float"  => 'checkBuiltin',
+        "complex" => 'checkBuiltin',
+        "choice" => 'checkChoice',
+        'file' => 'checkFile',
+    ];
 
     public function checkFile($opt, $value)
     {
         if (!file_exists($value)) {
-            throw new \Horde_Argv_OptionValueException(sprintf("%s: file does not exist", $value));
+            throw new Horde_Argv_OptionValueException(sprintf("%s: file does not exist", $value));
         } elseif (!is_file($value)) {
-            throw new \Horde_Argv_OptionValueException(sprintf("%s: not a regular file", $value));
+            throw new Horde_Argv_OptionValueException(sprintf("%s: not a regular file", $value));
         }
         return $value;
     }
 
 }
-

--- a/test/Horde/Argv/HelpTest.php
+++ b/test/Horde/Argv/HelpTest.php
@@ -1,10 +1,11 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_IndentedHelpFormatter;
-use \Horde_Cli_Color;
-use \Horde_Argv_OptionGroup;
-use \Horde_Argv_TitledHelpFormatter;
+
+use Horde_Argv_IndentedHelpFormatter;
+use Horde_Cli_Color;
+use Horde_Argv_OptionGroup;
+use Horde_Argv_TitledHelpFormatter;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -13,11 +14,11 @@ use \Horde_Argv_TitledHelpFormatter;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class HelpTest extends TestCase
 {
-
     public static $expected_help_basic = 'Usage: bar.php [options]
 
 Options:
@@ -70,7 +71,7 @@ Options:
         $this->parser = $this->makeParser(80);
         $this->origColumns = getenv('COLUMNS');
         if (!isset($_SERVER['argv'])) {
-            $_SERVER['argv'] = array('test');
+            $_SERVER['argv'] = ['test'];
         }
     }
 
@@ -82,47 +83,51 @@ Options:
 
     public function makeParser($columns)
     {
-        $options = array(
+        $options = [
             $this->makeOption(
                 "-a",
-                array(
+                [
                     'type'    => "string",
                     'dest'    => 'a',
                     'metavar' => "APPLE",
-                    'help'    => "throw APPLEs at basket"
-                )
+                    'help'    => "throw APPLEs at basket",
+                ]
             ),
             $this->makeOption(
-                "-b", "--boo",
-                array(
+                "-b",
+                "--boo",
+                [
                     'type'    => "int",
                     'dest'    => 'boo',
                     'metavar' => "NUM",
                     'help'    => "shout \"boo!\" NUM times (in order to frighten away "
-                        . "all the evil spirits that cause trouble and mayhem)"
-                )
+                        . "all the evil spirits that cause trouble and mayhem)",
+                ]
             ),
 
             $this->makeOption(
                 "--foo",
-                array(
+                [
                     'action' => 'append',
                     'type' => 'string',
                     'dest' => 'foo',
-                    'help' => "store FOO in the foo list for later fooing"
-                )
+                    'help' => "store FOO in the foo list for later fooing",
+                ]
             ),
-        );
+        ];
 
         putenv('COLUMNS=' . $columns);
 
-        return new InterceptingParser(array(
+        return new InterceptingParser([
             'optionList' => $options,
             'formatter' => new Horde_Argv_IndentedHelpFormatter(
-                2, 24, null, true,
+                2,
+                24,
+                null,
+                true,
                 new Horde_Cli_Color(Horde_Cli_Color::FORMAT_NONE)
-            )
-        ));
+            ),
+        ]);
     }
 
     public function assertHelpEquals($expectedOutput)
@@ -134,7 +139,7 @@ Options:
 
         $origArgv = $_SERVER['argv'];
         $_SERVER['argv'][0] = 'foo/bar.php';
-        $this->assertOutput(array('-h'), $expectedOutput);
+        $this->assertOutput(['-h'], $expectedOutput);
 
         $_SERVER['argv'] = $origArgv;
     }
@@ -159,7 +164,10 @@ Options:
     public function testHelpTitleFormatter()
     {
         $this->parser->formatter = new Horde_Argv_TitledHelpFormatter(
-            0, 24, null, true,
+            0,
+            24,
+            null,
+            true,
             new Horde_Cli_Color(Horde_Cli_Color::FORMAT_NONE)
         );
         $this->assertHelpEquals(self::$expected_help_title_formatter);
@@ -177,14 +185,17 @@ Options:
     public function testHelpDescriptionGroups()
     {
         $this->parser->setDescription(
-            "This is the program description for %prog.  %prog has " .
-            "an option group as well as single options.");
+            "This is the program description for %prog.  %prog has "
+            . "an option group as well as single options."
+        );
 
         $group = new Horde_Argv_OptionGroup(
-            $this->parser, "Dangerous Options",
-            "Caution: use of these options is at your own risk.  " .
-            "It is believed that some of them bite.");
-        $group->addOption("-g", array('action' => "store_true", 'help' => "Group option."));
+            $this->parser,
+            "Dangerous Options",
+            "Caution: use of these options is at your own risk.  "
+            . "It is believed that some of them bite."
+        );
+        $group->addOption("-g", ['action' => "store_true", 'help' => "Group option."]);
         $this->parser->addOptionGroup($group);
 
         $expect = 'Usage: bar.php [options]

--- a/test/Horde/Argv/InterceptedException.php
+++ b/test/Horde/Argv/InterceptedException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
  * @author     Mike Naberezny <mike@maintainable.com>
@@ -9,6 +10,7 @@
  */
 
 namespace Horde\Argv;
+
 use Exception;
 
 class InterceptedException extends Exception
@@ -24,12 +26,14 @@ class InterceptedException extends Exception
         $this->exit_message = $exit_message;
     }
 
-    public function __toString():string
+    public function __toString(): string
     {
-        if ($this->error_message)
+        if ($this->error_message) {
             return $this->error_message;
-        if ($this->exit_message)
+        }
+        if ($this->exit_message) {
             return $this->exit_message;
+        }
         return "intercepted error";
     }
 

--- a/test/Horde/Argv/InterceptingParser.php
+++ b/test/Horde/Argv/InterceptingParser.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Horde\Argv;
+
 use Horde_Argv_Parser;
 
 /**

--- a/test/Horde/Argv/MatchAbbrevTest.php
+++ b/test/Horde/Argv/MatchAbbrevTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Parser;
+
+use Horde_Argv_Parser;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,24 +11,29 @@ use \Horde_Argv_Parser;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class MatchAbbrevTest extends TestCase
 {
     public function testMatchAbbrev()
     {
-        $this->assertEquals(Horde_Argv_Parser::matchAbbrev("--f",
-            array("--foz" => null,
-                  "--foo" => null,
-                  "--fie" => null,
-                  "--f"   => null)),
-            '--f');
+        $this->assertEquals(
+            Horde_Argv_Parser::matchAbbrev(
+                "--f",
+                ["--foz" => null,
+                    "--foo" => null,
+                    "--fie" => null,
+                    "--f"   => null]
+            ),
+            '--f'
+        );
     }
 
     public function testMatchAbbrevError()
     {
         $s = '--f';
-        $wordmap = array("--foz" => null, "--foo" => null, "--fie" => null);
+        $wordmap = ["--foz" => null, "--foo" => null, "--fie" => null];
 
         $this->expectException('Horde_Argv_AmbiguousOptionException');
 

--- a/test/Horde/Argv/MultipleArgsAppendTest.php
+++ b/test/Horde/Argv/MultipleArgsAppendTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Option;
+
+use Horde_Argv_Option;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Option;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class MultipleArgsAppendTest extends TestCase
@@ -17,40 +19,48 @@ class MultipleArgsAppendTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->parser = new InterceptingParser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE));
-        $this->parser->addOption("-p", "--point", array(
-            'action' => "store", 'nargs' => 3, 'type' => 'float', 'dest' => 'point'));
-        $this->parser->addOption("-f", "--foo", array(
-            'action' => "append", 'nargs' => 2, 'type' => "int", 'dest' => "foo"));
-        $this->parser->addOption("-z", "--zero", array(
-            'action' => "append_const", 'dest' => "foo", 'const' => array(0, 0)));
+        $this->parser = new InterceptingParser(['usage' => Horde_Argv_Option::SUPPRESS_USAGE]);
+        $this->parser->addOption("-p", "--point", [
+            'action' => "store", 'nargs' => 3, 'type' => 'float', 'dest' => 'point']);
+        $this->parser->addOption("-f", "--foo", [
+            'action' => "append", 'nargs' => 2, 'type' => "int", 'dest' => "foo"]);
+        $this->parser->addOption("-z", "--zero", [
+            'action' => "append_const", 'dest' => "foo", 'const' => [0, 0]]);
     }
 
     public function testNargsAppend()
     {
-        $this->assertParseOK(array("-f", "4", "-3", "blah", "--foo", "1", "666"),
-                             array('point' => null, 'foo' => array(array(4, -3), array(1, 666))),
-                             array('blah'));
+        $this->assertParseOK(
+            ["-f", "4", "-3", "blah", "--foo", "1", "666"],
+            ['point' => null, 'foo' => [[4, -3], [1, 666]]],
+            ['blah']
+        );
     }
 
     public function testNargsAppendRequiredValues()
     {
-        $this->assertParseFail(array("-f4,3"),
-                               "-f option requires 2 arguments");
+        $this->assertParseFail(
+            ["-f4,3"],
+            "-f option requires 2 arguments"
+        );
     }
 
     public function testNargsAppendSimple()
     {
-        $this->assertParseOK(array("--foo=3", "4"),
-                             array('point' => null, 'foo' => array(array(3, 4))),
-                             array());
+        $this->assertParseOK(
+            ["--foo=3", "4"],
+            ['point' => null, 'foo' => [[3, 4]]],
+            []
+        );
     }
 
     public function testNargsAppendConst()
     {
-        $this->assertParseOK(array("--zero", "--foo", "3", "4", "-z"),
-                             array('point' => null, 'foo' => array(array(0, 0), array(3, 4), array(0, 0))),
-                             array());
+        $this->assertParseOK(
+            ["--zero", "--foo", "3", "4", "-z"],
+            ['point' => null, 'foo' => [[0, 0], [3, 4], [0, 0]]],
+            []
+        );
     }
 
 }

--- a/test/Horde/Argv/MultipleArgsTest.php
+++ b/test/Horde/Argv/MultipleArgsTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Option;
+
+use Horde_Argv_Option;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Option;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class MultipleArgsTest extends TestCase
@@ -17,35 +19,46 @@ class MultipleArgsTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->parser = new InterceptingParser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE));
-        $this->parser->addOption("-p", "--point",
-                                 array('action' => "store", 'nargs' => 3, 'type' => "float", 'dest' => "point"));
+        $this->parser = new InterceptingParser(['usage' => Horde_Argv_Option::SUPPRESS_USAGE]);
+        $this->parser->addOption(
+            "-p",
+            "--point",
+            ['action' => "store", 'nargs' => 3, 'type' => "float", 'dest' => "point"]
+        );
     }
 
     public function testNargsWithPositionalArgs()
     {
-        $this->assertParseOK(array("foo", "-p", "1", "2.5", "-4.3", "xyz"),
-                             array('point' => array(1.0, 2.5, -4.3)),
-                             array('foo', 'xyz'));
+        $this->assertParseOK(
+            ["foo", "-p", "1", "2.5", "-4.3", "xyz"],
+            ['point' => [1.0, 2.5, -4.3]],
+            ['foo', 'xyz']
+        );
     }
 
     public function testNargsLongOpt()
     {
-        $this->assertParseOK(array("--point", "-1", "2.5", "-0", "xyz"),
-                             array('point' => array(-1.0, 2.5, -0.0)),
-                             array("xyz"));
+        $this->assertParseOK(
+            ["--point", "-1", "2.5", "-0", "xyz"],
+            ['point' => [-1.0, 2.5, -0.0]],
+            ["xyz"]
+        );
     }
 
     public function testNargsInvalidFloatValue()
     {
-        $this->assertParseFail(array("-p", "1.0", "2x", "3.5"),
-                               "option -p: invalid floating-point value: '2x'");
+        $this->assertParseFail(
+            ["-p", "1.0", "2x", "3.5"],
+            "option -p: invalid floating-point value: '2x'"
+        );
     }
 
     public function testNargsRequiredValues()
     {
-        $this->assertParseFail(array("--point", "1.0", "3.5"),
-                               "--point option requires 3 arguments");
+        $this->assertParseFail(
+            ["--point", "1.0", "3.5"],
+            "--point option requires 3 arguments"
+        );
     }
 
 }

--- a/test/Horde/Argv/OptionChecksTest.php
+++ b/test/Horde/Argv/OptionChecksTest.php
@@ -1,8 +1,9 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Parser;
-use \Horde_Argv_Option;
+
+use Horde_Argv_Parser;
+use Horde_Argv_Option;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -11,6 +12,7 @@ use \Horde_Argv_Option;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class OptionChecksTest extends TestCase
@@ -18,12 +20,12 @@ class OptionChecksTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->parser = new Horde_Argv_Parser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE));
+        $this->parser = new Horde_Argv_Parser(['usage' => Horde_Argv_Option::SUPPRESS_USAGE]);
     }
 
     public function assertOptionError($expected_message, $args)
     {
-        $this->assertRaises(array($this, 'makeOption'), $args, 'Horde_Argv_OptionException', $expected_message);
+        $this->assertRaises([$this, 'makeOption'], $args, 'Horde_Argv_OptionException', $expected_message);
     }
 
     public function testOptStringEmpty()
@@ -37,25 +39,28 @@ class OptionChecksTest extends TestCase
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
             "invalid option string 'b': must be at least two characters long",
-            array("b"));
+            ["b"]
+        );
     }
 
     public function testOptStringShortInvalid()
     {
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
-            "invalid short option string '--': must be " .
-            "of the form -x, (x any non-dash char)",
-            array("--"));
+            "invalid short option string '--': must be "
+            . "of the form -x, (x any non-dash char)",
+            ["--"]
+        );
     }
 
     public function testOptStringLongInvalid()
     {
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
-            "invalid long option string '---': " .
-            "must start with --, followed by non-dash",
-            array("---"));
+            "invalid long option string '---': "
+            . "must start with --, followed by non-dash",
+            ["---"]
+        );
     }
 
     public function testAttrInvalid()
@@ -63,7 +68,8 @@ class OptionChecksTest extends TestCase
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
             "option -b: invalid keyword arguments: bar, foo",
-            array("-b", array('foo' => null, 'bar' => null)));
+            ["-b", ['foo' => null, 'bar' => null]]
+        );
     }
 
     public function testActionInvalid()
@@ -71,7 +77,8 @@ class OptionChecksTest extends TestCase
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
             "option -b: invalid action: 'foo'",
-            array("-b", array('action' => 'foo')));
+            ["-b", ['action' => 'foo']]
+        );
     }
 
     public function testTypeInvalid()
@@ -79,7 +86,8 @@ class OptionChecksTest extends TestCase
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
             "option -b: invalid option type: 'foo'",
-            array("-b", array('type' => 'foo')));
+            ["-b", ['type' => 'foo']]
+        );
     }
 
     public function testNoTypeForAction()
@@ -87,16 +95,18 @@ class OptionChecksTest extends TestCase
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
             "option -b: must not supply a type for action 'count'",
-            array("-b", array('action' => 'count', 'type' => 'int')));
+            ["-b", ['action' => 'count', 'type' => 'int']]
+        );
     }
 
     public function testNoChoicesList()
     {
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
-            "option -b/--bad: must supply a list of " .
-            "choices for type 'choice'",
-            array("-b", "--bad", array('type' => "choice")));
+            "option -b/--bad: must supply a list of "
+            . "choices for type 'choice'",
+            ["-b", "--bad", ['type' => "choice"]]
+        );
     }
 
     public function testBadChoicesList()
@@ -104,9 +114,10 @@ class OptionChecksTest extends TestCase
         $this->expectException('Horde_Argv_OptionException');
         $typename = gettype('');
         $this->assertOptionError(
-            sprintf("option -b/--bad: choices must be a list of " .
-                    "strings ('%s' supplied)", $typename),
-            array("-b", "--bad", array('type' => 'choice', 'choices' => 'bad choices')));
+            sprintf("option -b/--bad: choices must be a list of "
+                    . "strings ('%s' supplied)", $typename),
+            ["-b", "--bad", ['type' => 'choice', 'choices' => 'bad choices']]
+        );
     }
 
     public function testNoChoicesForType()
@@ -114,7 +125,8 @@ class OptionChecksTest extends TestCase
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
             "option -b: must not supply choices for type 'int'",
-            array("-b", array('type' => 'int', 'choices' => "bad")));
+            ["-b", ['type' => 'int', 'choices' => "bad"]]
+        );
     }
 
     public function testNoConstForAction()
@@ -122,7 +134,8 @@ class OptionChecksTest extends TestCase
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
             "option -b: 'const' must not be supplied for action 'store'",
-            array("-b", array('action' => 'store', 'const' => 1)));
+            ["-b", ['action' => 'store', 'const' => 1]]
+        );
     }
 
     public function testNoNargsForAction()
@@ -130,7 +143,8 @@ class OptionChecksTest extends TestCase
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
             "option -b: 'nargs' must not be supplied for action 'count'",
-            array("-b", array('action' => 'count', 'nargs' => 2)));
+            ["-b", ['action' => 'count', 'nargs' => 2]]
+        );
     }
 
     public function testCallbackNotCallable()
@@ -138,22 +152,22 @@ class OptionChecksTest extends TestCase
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
             "option -b: callback not callable: 'foo'",
-            array("-b", array('action' => 'callback', 'callback' => 'foo')));
+            ["-b", ['action' => 'callback', 'callback' => 'foo']]
+        );
     }
 
-    public function dummy()
-    {
-    }
+    public function dummy() {}
 
     public function testCallbackArgsNoArray()
     {
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
-            "option -b: callbackArgs, if supplied, " .
-            "must be an array: not 'foo'",
-            array("-b", array('action' => 'callback',
-                              'callback' => array($this, 'dummy'),
-                              'callbackArgs' => 'foo')));
+            "option -b: callbackArgs, if supplied, "
+            . "must be an array: not 'foo'",
+            ["-b", ['action' => 'callback',
+                'callback' => [$this, 'dummy'],
+                'callbackArgs' => 'foo']]
+        );
     }
 
     public function testNoCallbackForAction()
@@ -161,8 +175,9 @@ class OptionChecksTest extends TestCase
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
             "option -b: callback supplied ('foo') for non-callback option",
-            array("-b", array('action' => 'store',
-                              'callback' => 'foo')));
+            ["-b", ['action' => 'store',
+                'callback' => 'foo']]
+        );
     }
 
     public function testNoCallbackArgsForAction()
@@ -170,8 +185,9 @@ class OptionChecksTest extends TestCase
         $this->expectException('Horde_Argv_OptionException');
         $this->assertOptionError(
             "option -b: callbackArgs supplied for non-callback option",
-            array("-b", array('action' => 'store',
-                              'callbackArgs' => 'foo')));
+            ["-b", ['action' => 'store',
+                'callbackArgs' => 'foo']]
+        );
     }
 
 }

--- a/test/Horde/Argv/OptionGroupTest.php
+++ b/test/Horde/Argv/OptionGroupTest.php
@@ -1,9 +1,10 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Parser;
-use \Horde_Argv_Option;
-use \Horde_Argv_OptionGroup;
+
+use Horde_Argv_Parser;
+use Horde_Argv_Option;
+use Horde_Argv_OptionGroup;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -12,6 +13,7 @@ use \Horde_Argv_OptionGroup;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class OptionGroupTest extends TestCase
@@ -19,30 +21,36 @@ class OptionGroupTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->parser = new Horde_Argv_Parser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE));
+        $this->parser = new Horde_Argv_Parser(['usage' => Horde_Argv_Option::SUPPRESS_USAGE]);
     }
 
     public function testOptionGroupCreateInstance()
     {
         $group = new Horde_Argv_OptionGroup($this->parser, "Spam");
         $this->parser->addOptionGroup($group);
-        $group->addOption("--spam", array('action' => "store_true",
-                                          'help' => "spam spam spam spam"));
-        $this->assertParseOK(array("--spam"), array('spam' => true), array());
+        $group->addOption("--spam", ['action' => "store_true",
+            'help' => "spam spam spam spam"]);
+        $this->assertParseOK(["--spam"], ['spam' => true], []);
     }
 
     public function testAddGroupNoGroup()
     {
         $this->expectException('InvalidArgumentException');
-        $this->assertTypeError(array($this->parser, 'addOptionGroup'),
-                               "not an OptionGroup instance: NULL", array(null));
+        $this->assertTypeError(
+            [$this->parser, 'addOptionGroup'],
+            "not an OptionGroup instance: NULL",
+            [null]
+        );
     }
 
     public function testAddGroupInvalidArguments()
     {
         $this->expectException('InvalidArgumentException');
-        $this->assertTypeError(array($this->parser, 'addOptionGroup'),
-                               "invalid arguments", null);
+        $this->assertTypeError(
+            [$this->parser, 'addOptionGroup'],
+            "invalid arguments",
+            null
+        );
     }
 
     public function testAddGroupWrongParser()
@@ -50,16 +58,22 @@ class OptionGroupTest extends TestCase
         $this->expectException('InvalidArgumentException');
         $group = new Horde_Argv_OptionGroup($this->parser, "Spam");
         $group->parser = new Horde_Argv_Parser();
-        $this->assertRaises(array($this->parser, 'addOptionGroup'), array($group),
-                            'InvalidArgumentException', "invalid OptionGroup (wrong parser)");
+        $this->assertRaises(
+            [$this->parser, 'addOptionGroup'],
+            [$group],
+            'InvalidArgumentException',
+            "invalid OptionGroup (wrong parser)"
+        );
     }
 
     public function testGroupManipulate()
     {
-        $group = $this->parser->addOptionGroup("Group 2",
-                                               array('description' => "Some more options"));
+        $group = $this->parser->addOptionGroup(
+            "Group 2",
+            ['description' => "Some more options"]
+        );
         $group->setTitle("Bacon");
-        $group->addOption("--bacon", array('type' => "int"));
+        $group->addOption("--bacon", ['type' => "int"]);
         $this->assertSame($group, $this->parser->getOptionGroup("--bacon"));
     }
 

--- a/test/Horde/Argv/OptionValuesTest.php
+++ b/test/Horde/Argv/OptionValuesTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Values;
+
+use Horde_Argv_Values;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Values;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class OptionValuesTest extends TestCase
@@ -17,15 +19,15 @@ class OptionValuesTest extends TestCase
     public function testBasics()
     {
         $values = new Horde_Argv_Values();
-        $this->assertEquals(array(), iterator_to_array($values));
-        $this->assertNotEquals(array('foo' => 'bar'), $values);
-        $this->assertEquals('', (string)$values);
+        $this->assertEquals([], iterator_to_array($values));
+        $this->assertNotEquals(['foo' => 'bar'], $values);
+        $this->assertEquals('', (string) $values);
 
-        $dict = array('foo' => 'bar', 'baz' => 42);
+        $dict = ['foo' => 'bar', 'baz' => 42];
         $values = new Horde_Argv_Values($dict);
         $this->assertEquals($dict, iterator_to_array($values));
-        $this->assertNotEquals(array('foo' => 'bar'), $values);
-        $this->assertNotEquals(array(), $values);
-        $this->assertNotEquals('', (string)$values);
+        $this->assertNotEquals(['foo' => 'bar'], $values);
+        $this->assertNotEquals([], $values);
+        $this->assertNotEquals('', (string) $values);
     }
 }

--- a/test/Horde/Argv/ParseNumTest.php
+++ b/test/Horde/Argv/ParseNumTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Option;
+
+use Horde_Argv_Option;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Option;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class ParseNumTest extends TestCase
@@ -18,8 +20,8 @@ class ParseNumTest extends TestCase
     {
         parent::setUp();
         $this->parser = new InterceptingParser();
-        $this->parser->addOption('-n', array('type' => 'int'));
-        $this->parser->addOption('-l', array('type' => 'long'));
+        $this->parser->addOption('-n', ['type' => 'int']);
+        $this->parser->addOption('-l', ['type' => 'long']);
     }
 
     public function testParseNumFail()
@@ -30,35 +32,57 @@ class ParseNumTest extends TestCase
 
     public function testParseNumOk()
     {
-        $this->assertSame(0,
-                          Horde_Argv_Option::parseNumber('0'));
-        $this->assertSame(16,
-                          Horde_Argv_Option::parseNumber('0x10'));
-        $this->assertSame(10,
-                          Horde_Argv_Option::parseNumber('0XA'));
-        $this->assertSame(8,
-                          Horde_Argv_Option::parseNumber('010'));
-        $this->assertSame(3,
-                          Horde_Argv_Option::parseNumber('0b11'));
-        $this->assertSame(0,
-                          Horde_Argv_Option::parseNumber('0b'));
+        $this->assertSame(
+            0,
+            Horde_Argv_Option::parseNumber('0')
+        );
+        $this->assertSame(
+            16,
+            Horde_Argv_Option::parseNumber('0x10')
+        );
+        $this->assertSame(
+            10,
+            Horde_Argv_Option::parseNumber('0XA')
+        );
+        $this->assertSame(
+            8,
+            Horde_Argv_Option::parseNumber('010')
+        );
+        $this->assertSame(
+            3,
+            Horde_Argv_Option::parseNumber('0b11')
+        );
+        $this->assertSame(
+            0,
+            Horde_Argv_Option::parseNumber('0b')
+        );
     }
 
     public function testNumericOptions()
     {
-        $this->assertParseOk(array("-n", "42", "-l", "0x20"),
-                             array("n" => 42, "l" => 0x20), array());
+        $this->assertParseOk(
+            ["-n", "42", "-l", "0x20"],
+            ["n" => 42, "l" => 0x20],
+            []
+        );
 
-        $this->assertParseOk(array("-n", "0b0101", "-l010"),
-                             array("n" => 5, "l" => 8), array());
+        $this->assertParseOk(
+            ["-n", "0b0101", "-l010"],
+            ["n" => 5, "l" => 8],
+            []
+        );
 
-        $this->assertParseFail(array("-n008"),
-                               "option -n: invalid integer value: '008'");
+        $this->assertParseFail(
+            ["-n008"],
+            "option -n: invalid integer value: '008'"
+        );
 
-        $this->assertParseFail(array("-l0b0123"),
-                               "option -l: invalid long integer value: '0b0123'");
+        $this->assertParseFail(
+            ["-l0b0123"],
+            "option -l: invalid long integer value: '0b0123'"
+        );
 
-        $this->assertParseFail(array("-l", "0x12x"),
-                               "option -l: invalid long integer value: '0x12x'");
+        $this->assertParseFail(["-l", "0x12x"],
+            "option -l: invalid long integer value: '0x12x'");
     }
 }

--- a/test/Horde/Argv/ParserTest.php
+++ b/test/Horde/Argv/ParserTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Parser;
+
+use Horde_Argv_Parser;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Parser;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class ParserTest extends TestCase
@@ -18,32 +20,47 @@ class ParserTest extends TestCase
     {
         parent::setUp();
         $this->parser = new Horde_Argv_Parser();
-        $this->parser->addOption('-v', '--verbose', '-n', '--noisy',
-                                  array('action' => 'store_true', 'dest' => 'verbose'));
-        $this->parser->addOption('-q', '--quiet', '--silent',
-                                  array('action' => 'store_false', 'dest' => 'verbose'));
+        $this->parser->addOption(
+            '-v',
+            '--verbose',
+            '-n',
+            '--noisy',
+            ['action' => 'store_true', 'dest' => 'verbose']
+        );
+        $this->parser->addOption(
+            '-q',
+            '--quiet',
+            '--silent',
+            ['action' => 'store_false', 'dest' => 'verbose']
+        );
     }
 
     public function testAddOptionNoOption()
     {
         $this->expectException('InvalidArgumentException');
-        $this->assertTypeError(array($this->parser, 'addOption'),
-                               "not an Option instance: NULL", array(null));
+        $this->assertTypeError(
+            [$this->parser, 'addOption'],
+            "not an Option instance: NULL",
+            [null]
+        );
     }
 
     public function testAddOptionInvalidArguments()
     {
         $this->expectException('InvalidArgumentException');
-        $this->assertTypeError(array($this->parser, 'addOption'),
-                               "invalid arguments", null);
+        $this->assertTypeError(
+            [$this->parser, 'addOption'],
+            "invalid arguments",
+            null
+        );
     }
 
     public function testGetOption()
     {
         $opt1 = $this->parser->getOption("-v");
         $this->assertInstanceOf('Horde_Argv_Option', $opt1);
-        $this->assertEquals($opt1->shortOpts, array("-v", "-n"));
-        $this->assertEquals($opt1->longOpts, array("--verbose", "--noisy"));
+        $this->assertEquals($opt1->shortOpts, ["-v", "-n"]);
+        $this->assertEquals($opt1->longOpts, ["--verbose", "--noisy"]);
         $this->assertEquals($opt1->action, "store_true");
         $this->assertEquals($opt1->dest, "verbose");
     }
@@ -96,7 +113,7 @@ class ParserTest extends TestCase
     public function testRemoveNonexistent()
     {
         $this->expectException('InvalidArgumentException');
-        $this->assertRaises(array($this->parser, 'removeOption'), array('foo'), 'InvalidArgumentException', "no such option 'foo'");
+        $this->assertRaises([$this->parser, 'removeOption'], ['foo'], 'InvalidArgumentException', "no such option 'foo'");
     }
 
     /**

--- a/test/Horde/Argv/ProgNameTest.php
+++ b/test/Horde/Argv/ProgNameTest.php
@@ -1,9 +1,10 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Parser;
-use \Horde_Argv_IndentedHelpFormatter;
-use \Horde_Cli_Color;
+
+use Horde_Argv_Parser;
+use Horde_Argv_IndentedHelpFormatter;
+use Horde_Cli_Color;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -12,6 +13,7 @@ use \Horde_Cli_Color;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class ProgNameTest extends TestCase
@@ -19,7 +21,7 @@ class ProgNameTest extends TestCase
     public function setUp(): void
     {
         if (!isset($_SERVER['argv'])) {
-            $_SERVER['argv'] = array('test');
+            $_SERVER['argv'] = ['test'];
         }
     }
 
@@ -45,14 +47,17 @@ class ProgNameTest extends TestCase
         $saveArgv = $_SERVER['argv'];
         try {
             $_SERVER['argv'][0] = 'foo/bar/baz.php';
-            $parser = new Horde_Argv_Parser(array(
+            $parser = new Horde_Argv_Parser([
                 'usage' => "%prog ...",
                 'version' => "%prog 1.2",
                 'formatter' => new Horde_Argv_IndentedHelpFormatter(
-                    2, 24, null, true,
+                    2,
+                    24,
+                    null,
+                    true,
                     new Horde_Cli_Color(Horde_Cli_Color::FORMAT_NONE)
-                )
-            ));
+                ),
+            ]);
             $expectedUsage = "Usage: baz.php ...\n";
         } catch (Exception $e) {
             $_SERVER['argv'] = $saveArgv;
@@ -61,24 +66,29 @@ class ProgNameTest extends TestCase
 
         $this->assertUsage($parser, $expectedUsage);
         $this->assertVersion($parser, "baz.php 1.2");
-        $this->assertHelp($parser,
-                          $expectedUsage . "\n" .
-                          "Options:\n" .
-                          "  --version   show program's version number and exit\n" .
-                          "  -h, --help  show this help message and exit\n");
+        $this->assertHelp(
+            $parser,
+            $expectedUsage . "\n"
+                          . "Options:\n"
+                          . "  --version   show program's version number and exit\n"
+                          . "  -h, --help  show this help message and exit\n"
+        );
     }
 
     public function testCustomProgName()
     {
-        $parser = new Horde_Argv_Parser(array(
+        $parser = new Horde_Argv_Parser([
             'prog' => 'thingy',
             'version' => "%prog 0.1",
             'usage' => "%prog arg arg",
             'formatter' => new Horde_Argv_IndentedHelpFormatter(
-                2, 24, null, true,
+                2,
+                24,
+                null,
+                true,
                 new Horde_Cli_Color(Horde_Cli_Color::FORMAT_NONE)
-            )
-        ));
+            ),
+        ]);
         $parser->removeOption('-h');
         $parser->removeOption('--version');
         $expectedUsage = "Usage: thingy arg arg\n";

--- a/test/Horde/Argv/StandardTest.php
+++ b/test/Horde/Argv/StandardTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Option;
+
+use Horde_Argv_Option;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Option;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class StandardTest extends TestCase
@@ -17,121 +19,152 @@ class StandardTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $options = array(
-            $this->makeOption('-a', array('type' => 'string')),
-            $this->makeOption('-b', '--boo', array('type' => 'int', 'dest' => 'boo')),
-            $this->makeOption('--foo', array('action' => 'append'))
-        );
+        $options = [
+            $this->makeOption('-a', ['type' => 'string']),
+            $this->makeOption('-b', '--boo', ['type' => 'int', 'dest' => 'boo']),
+            $this->makeOption('--foo', ['action' => 'append']),
+        ];
 
-        $this->parser = new InterceptingParser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE,
-                                                                'optionList' => $options));
+        $this->parser = new InterceptingParser(['usage' => Horde_Argv_Option::SUPPRESS_USAGE,
+            'optionList' => $options]);
     }
 
     public function testRequiredValue()
     {
-        $this->assertParseFail(array('-a'),
-                               '-a option requires an argument');
+        $this->assertParseFail(
+            ['-a'],
+            '-a option requires an argument'
+        );
     }
 
     public function testInvalidInteger()
     {
-        $this->assertParseFail(array('-b', '5x'),
-                               "option -b: invalid integer value: '5x'");
+        $this->assertParseFail(
+            ['-b', '5x'],
+            "option -b: invalid integer value: '5x'"
+        );
     }
 
     public function testNoSuchOption()
     {
-        $this->assertParseFail(array('--boo13'),
-                               "no such option: --boo13");
+        $this->assertParseFail(
+            ['--boo13'],
+            "no such option: --boo13"
+        );
     }
 
     public function testLongInvalidInteger()
     {
-        $this->assertParseFail(array("--boo=x5"),
-                               "option --boo: invalid integer value: 'x5'");
+        $this->assertParseFail(
+            ["--boo=x5"],
+            "option --boo: invalid integer value: 'x5'"
+        );
     }
 
     public function testEmpty()
     {
-        $this->assertParseOk(array(),
-                             array('a' => null, 'boo' => null, 'foo' => null), array());
+        $this->assertParseOk(
+            [],
+            ['a' => null, 'boo' => null, 'foo' => null],
+            []
+        );
     }
 
     public function testShortOptEmptyLongOptAppend()
     {
-        $this->assertParseOk(array("-a", "", "--foo=blah", "--foo="),
-                             array('a' => "", 'boo' => null, 'foo' => array("blah", "")),
-                             array());
+        $this->assertParseOk(
+            ["-a", "", "--foo=blah", "--foo="],
+            ['a' => "", 'boo' => null, 'foo' => ["blah", ""]],
+            []
+        );
     }
 
     public function testLongOptionAppend()
     {
-        $this->assertParseOk(array("--foo", "bar", "--foo", "", "--foo=x"),
-                             array('a' => null,
-                                   'boo' => null,
-                                   'foo' => array('bar', '', 'x')),
-                             array());
+        $this->assertParseOk(
+            ["--foo", "bar", "--foo", "", "--foo=x"],
+            ['a' => null,
+                'boo' => null,
+                'foo' => ['bar', '', 'x']],
+            []
+        );
     }
 
     public function testOptionArgumentJoined()
     {
-        $this->assertParseOk(array("-abc"),
-                             array('a' => "bc", 'boo' => null, 'foo' => null),
-                             array());
+        $this->assertParseOk(
+            ["-abc"],
+            ['a' => "bc", 'boo' => null, 'foo' => null],
+            []
+        );
     }
 
     public function testOptionArgumentSplit()
     {
-        $this->assertParseOk(array("-a", "34"),
-                             array('a' => "34", 'boo' => null, 'foo' => null),
-                             array());
+        $this->assertParseOk(
+            ["-a", "34"],
+            ['a' => "34", 'boo' => null, 'foo' => null],
+            []
+        );
     }
 
     public function testOptionArgumentJoinedInteger()
     {
-        $this->assertParseOk(array("-b34"),
-                             array('a' => null, 'boo' => 34, 'foo' => null),
-                             array());
+        $this->assertParseOk(
+            ["-b34"],
+            ['a' => null, 'boo' => 34, 'foo' => null],
+            []
+        );
     }
 
     public function testOptionArgumentSplitNegativeInteger()
     {
-        $this->assertParseOk(array("-b", "-5"),
-                             array('a' => null, 'boo' => -5, 'foo' => null),
-                             array());
+        $this->assertParseOk(
+            ["-b", "-5"],
+            ['a' => null, 'boo' => -5, 'foo' => null],
+            []
+        );
     }
 
     public function testLongOptionArgumentJoined()
     {
-        $this->assertParseOk(array("--boo=13"),
-                             array('a' => null, 'boo' => 13, 'foo' => null),
-                             array());
+        $this->assertParseOk(
+            ["--boo=13"],
+            ['a' => null, 'boo' => 13, 'foo' => null],
+            []
+        );
     }
 
     public function testLongOptionArgumentSplit()
     {
-        $this->assertParseOk(array("--boo", "111"),
-                             array('a' => null, 'boo' => 111, 'foo' => null),
-                             array());
+        $this->assertParseOk(
+            ["--boo", "111"],
+            ['a' => null, 'boo' => 111, 'foo' => null],
+            []
+        );
     }
 
     public function testLongOptionShortOption()
     {
-        $this->assertParseOk(array("--foo=bar", "-axyz"),
-                             array('a' => 'xyz', 'boo' => null, 'foo' => array("bar")),
-                             array());
+        $this->assertParseOk(
+            ["--foo=bar", "-axyz"],
+            ['a' => 'xyz', 'boo' => null, 'foo' => ["bar"]],
+            []
+        );
     }
 
     public function testAbbrevLongOption()
     {
-        $this->assertParseOk(array("--f=bar", "-axyz"),
-                             array('a' => 'xyz', 'boo' => null, 'foo' => array("bar")),
-                             array());
+        $this->assertParseOk(
+            ["--f=bar", "-axyz"],
+            ['a' => 'xyz', 'boo' => null, 'foo' => ["bar"]],
+            []
+        );
     }
 
     public function testDefaults()
     {
-        list($options, $args) = $this->parser->parseArgs(array());
+        [$options, $args] = $this->parser->parseArgs([]);
         $defaults = $this->parser->getDefaultValues();
 
         $this->assertEquals($defaults, $options);
@@ -139,70 +172,87 @@ class StandardTest extends TestCase
 
     public function testAmbiguousOption()
     {
-        $this->parser->addOption("--foz", array('action' => 'store',
-                                                'type' => 'string', 'dest' => 'foo'));
-        $this->assertParseFail(array('--f=bar'),
-                               "ambiguous option: --f (--foo, --foz?)");
+        $this->parser->addOption("--foz", ['action' => 'store',
+            'type' => 'string', 'dest' => 'foo']);
+        $this->assertParseFail(
+            ['--f=bar'],
+            "ambiguous option: --f (--foo, --foz?)"
+        );
     }
 
     public function testShortAndLongOptionSplit()
     {
-        $this->assertParseOk(array("-a", "xyz", "--foo", "bar"),
-                             array('a' => 'xyz', 'boo' => null, 'foo' => array("bar")),
-                             array());
+        $this->assertParseOk(
+            ["-a", "xyz", "--foo", "bar"],
+            ['a' => 'xyz', 'boo' => null, 'foo' => ["bar"]],
+            []
+        );
     }
 
     public function testShortOptionSplitLongOptionAppend()
     {
-        $this->assertParseOk(array("--foo=bar", "-b", "123", "--foo", "baz"),
-                             array('a' => null, 'boo' => 123, 'foo' => array("bar", "baz")),
-                             array());
+        $this->assertParseOk(
+            ["--foo=bar", "-b", "123", "--foo", "baz"],
+            ['a' => null, 'boo' => 123, 'foo' => ["bar", "baz"]],
+            []
+        );
     }
 
     public function testShortOptionSplitOnePositionalArg()
     {
-        $this->assertParseOk(array("-a", "foo", "bar"),
-                             array('a' => "foo", 'boo' => null, 'foo' => null),
-                             array("bar"));
+        $this->assertParseOk(
+            ["-a", "foo", "bar"],
+            ['a' => "foo", 'boo' => null, 'foo' => null],
+            ["bar"]
+        );
     }
 
     public function testShortOptionConsumesSeparator()
     {
-        $this->assertParseOk(array("-a", "--", "foo", "bar"),
-                             array('a' => "--", 'boo' => null, 'foo' => null),
-                             array("foo", "bar"));
+        $this->assertParseOk(
+            ["-a", "--", "foo", "bar"],
+            ['a' => "--", 'boo' => null, 'foo' => null],
+            ["foo", "bar"]
+        );
 
-        $this->assertParseOk(array("-a", "--", "--foo", "bar"),
-                             array('a' => "--", 'boo' => null, 'foo' => array("bar")),
-                             array());
+        $this->assertParseOk(
+            ["-a", "--", "--foo", "bar"],
+            ['a' => "--", 'boo' => null, 'foo' => ["bar"]],
+            []
+        );
     }
 
     public function testShortOptionJoinedAndSeparator()
     {
-        $this->assertParseOk(array("-ab", "--", "--foo", "bar"),
-                             array('a' => "b", 'boo' => null, 'foo' => null),
-                             array("--foo", "bar"));
+        $this->assertParseOk(
+            ["-ab", "--", "--foo", "bar"],
+            ['a' => "b", 'boo' => null, 'foo' => null],
+            ["--foo", "bar"]
+        );
     }
 
     public function testHyphenBecomesPositionalArg()
     {
-        $this->assertParseOk(array("-ab", "-", "--foo", "bar"),
-                             array('a' => "b", 'boo' => null, 'foo' => array("bar")),
-                             array("-"));
+        $this->assertParseOk(
+            ["-ab", "-", "--foo", "bar"],
+            ['a' => "b", 'boo' => null, 'foo' => ["bar"]],
+            ["-"]
+        );
     }
 
     public function testNoAppendVersusAppend()
     {
-        $this->assertParseOk(array("-b3", "-b", "5", "--foo=bar", "--foo", "baz"),
-                             array('a' => null, 'boo' => 5, 'foo' => array("bar", "baz")),
-                             array());
+        $this->assertParseOk(
+            ["-b3", "-b", "5", "--foo=bar", "--foo", "baz"],
+            ['a' => null, 'boo' => 5, 'foo' => ["bar", "baz"]],
+            []
+        );
     }
 
     public function testOptionConsumesOptionLikeString()
     {
-        $this->assertParseOk(array("-a", "-b3"),
-                             array('a' => "-b3", 'boo' => null, 'foo' => null),
-                             array());
+        $this->assertParseOk(["-a", "-b3"],
+            ['a' => "-b3", 'boo' => null, 'foo' => null],
+            []);
     }
 }
-

--- a/test/Horde/Argv/TestCase.php
+++ b/test/Horde/Argv/TestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
  * @author     Mike Naberezny <mike@maintainable.com>
@@ -7,10 +8,15 @@
  * @package    Argv
  * @subpackage UnitTests
  */
-namespace Horde\Argv;
-use PHPUnit\Framework\TestCase as PHPTestCase;
-use \ReflectionClass;
 
+namespace Horde\Argv;
+
+use PHPUnit\Framework\TestCase as PHPTestCase;
+use ReflectionClass;
+
+/**
+ * @coversNothing
+ */
 class TestCase extends PHPTestCase
 {
     public $parser;
@@ -46,16 +52,22 @@ class TestCase extends PHPTestCase
      */
     public function assertParseOK($args, $expected_opts, $expected_positional_args)
     {
-        list($options, $positional_args) = $this->parser->parseArgs($args);
+        [$options, $positional_args] = $this->parser->parseArgs($args);
         $optdict = iterator_to_array($options);
 
-        $this->assertEquals($expected_opts, $optdict,
-                            'Expected options don\'t match. Args were ' . print_r($args, true));
+        $this->assertEquals(
+            $expected_opts,
+            $optdict,
+            'Expected options don\'t match. Args were ' . print_r($args, true)
+        );
 
-        $this->assertEquals($positional_args, $expected_positional_args,
-                            'Positional arguments don\'t match. Args were ' . print_r($args, true));
+        $this->assertEquals(
+            $positional_args,
+            $expected_positional_args,
+            'Positional arguments don\'t match. Args were ' . print_r($args, true)
+        );
 
-        return array($options, $positional_args);
+        return [$options, $positional_args];
     }
 
     /**
@@ -72,8 +84,12 @@ class TestCase extends PHPTestCase
      *
      *  Returns the exception raised for further testing.
      */
-    public function assertRaises($func, $args,
-                                 $expected_exception, $expected_message) {
+    public function assertRaises(
+        $func,
+        $args,
+        $expected_exception,
+        $expected_message
+    ) {
         $caught = false;
         try {
             if (is_array($args)) {
@@ -101,12 +117,12 @@ class TestCase extends PHPTestCase
      */
     public function assertParseFail($cmdline_args, $expected_output)
     {
-//        $this->markTestSkipped('Parser undefined. ');
+        //        $this->markTestSkipped('Parser undefined. ');
 
         try {
-            list($options, $positional_args) = $this->parser->parseArgs($cmdline_args);
+            [$options, $positional_args] = $this->parser->parseArgs($cmdline_args);
         } catch (InterceptedException $e) {
-            $this->assertEquals($expected_output, (string)$e);
+            $this->assertEquals($expected_output, (string) $e);
             return true;
         } catch (Exception $e) {
             $this->fail("unexpected Exception: " . $e->getMessage());
@@ -122,8 +138,8 @@ class TestCase extends PHPTestCase
         $cmdline_args,
         $expected_output,
         $expected_status = 0,
-        $expected_error = null)
-    {
+        $expected_error = null
+    ) {
         ob_start();
         try {
             $this->parser->parseArgs($cmdline_args);

--- a/test/Horde/Argv/TypeAliasesTest.php
+++ b/test/Horde/Argv/TypeAliasesTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Parser;
+
+use Horde_Argv_Parser;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Parser;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class TypeAliasesTest extends TestCase
@@ -22,15 +24,15 @@ class TypeAliasesTest extends TestCase
 
     public function testStrAliasesString()
     {
-        $this->parser->addOption("-s", array('type' => "str"));
+        $this->parser->addOption("-s", ['type' => "str"]);
         $this->assertEquals($this->parser->getOption("-s")->type, "string");
     }
 
     public function testNewTypeObject()
     {
-        $this->parser->addOption("-s", array('type' => 'str'));
+        $this->parser->addOption("-s", ['type' => 'str']);
         $this->assertEquals($this->parser->getOption("-s")->type, "string");
-        $this->parser->addOption("-x", array('type' => 'int'));
+        $this->parser->addOption("-x", ['type' => 'int']);
         $this->assertEquals($this->parser->getOption("-x")->type, "int");
     }
 

--- a/test/Horde/Argv/VersionTest.php
+++ b/test/Horde/Argv/VersionTest.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Horde\Argv;
-use \Horde_Argv_Option;
+
+use Horde_Argv_Option;
 
 /**
  * @author     Chuck Hagenbuch <chuck@horde.org>
@@ -10,6 +11,7 @@ use \Horde_Argv_Option;
  * @category   Horde
  * @package    Argv
  * @subpackage UnitTests
+ * @coversNothing
  */
 
 class VersionTest extends TestCase
@@ -17,7 +19,7 @@ class VersionTest extends TestCase
     public function setUp(): void
     {
         if (!isset($_SERVER['argv'])) {
-            $_SERVER['argv'] = array('test');
+            $_SERVER['argv'] = ['test'];
         }
     }
 
@@ -28,13 +30,13 @@ class VersionTest extends TestCase
 
     public function testVersion()
     {
-        $this->parser = new InterceptingParser(array(
+        $this->parser = new InterceptingParser([
             'usage'   => Horde_Argv_Option::SUPPRESS_USAGE,
-            'version' => "%prog 0.1"));
+            'version' => "%prog 0.1"]);
         $saveArgv = $_SERVER['argv'];
         try {
             $_SERVER['argv'][0] = __DIR__ . '/foo/bar';
-            $this->assertOutput(array("--version"), "bar 0.1\n");
+            $this->assertOutput(["--version"], "bar 0.1\n");
         } catch (Exception $e) {
             $_SERVER['argv'] = $saveArgv;
             throw $e;
@@ -45,7 +47,7 @@ class VersionTest extends TestCase
 
     public function testNoVersion()
     {
-        $this->parser = new InterceptingParser(array('usage' => Horde_Argv_Option::SUPPRESS_USAGE));
-        $this->assertParseFail(array("--version"), "no such option: --version");
+        $this->parser = new InterceptingParser(['usage' => Horde_Argv_Option::SUPPRESS_USAGE]);
+        $this->assertParseFail(["--version"], "no such option: --version");
     }
 }

--- a/test/ImmutableParserHelpTest.php
+++ b/test/ImmutableParserHelpTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2024-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Argv
+ */
+
+namespace Horde\Argv\Test;
+
+use Horde\Argv\ImmutableParser;
+use Horde\Argv\Modern\Builder\{ParserBuilder, OptionBuilder, GroupBuilder};
+use Horde\Argv\Modern\Help\HelpFormatter;
+use Horde\Argv\Modern\Enum\OptionType;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(ImmutableParser::class)]
+class ImmutableParserHelpTest extends TestCase
+{
+    public function testParserCanFormatHelp(): void
+    {
+        $parser = ParserBuilder::create()
+            ->withUsage('%prog [options]')
+            ->withProg('myapp')
+            ->build();
+
+        $help = $parser->formatHelp();
+
+        $this->assertIsString($help);
+        $this->assertStringContainsString('Usage: myapp', $help);
+    }
+
+    public function testParserFormatHelpWithOptions(): void
+    {
+        $option = OptionBuilder::create()
+            ->short('-v')
+            ->long('--verbose')
+            ->flag()
+            ->help('Enable verbose output')
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->withUsage('%prog [options]')
+            ->withProg('test')
+            ->addOption($option)
+            ->build();
+
+        $help = $parser->formatHelp();
+
+        $this->assertStringContainsString('-v', $help);
+        $this->assertStringContainsString('--verbose', $help);
+        $this->assertStringContainsString('Enable verbose output', $help);
+    }
+
+    public function testParserFormatHelpWithGroups(): void
+    {
+        $debugOption = OptionBuilder::create()
+            ->short('-d')
+            ->flag()
+            ->help('Debug mode')
+            ->build();
+
+        $group = GroupBuilder::create('Debugging')
+            ->addOption($debugOption)
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->withUsage('%prog')
+            ->withProg('test')
+            ->addGroup($group)
+            ->build();
+
+        $help = $parser->formatHelp();
+
+        $this->assertStringContainsString('Debugging:', $help);
+        $this->assertStringContainsString('-d', $help);
+    }
+
+    public function testParserFormatHelpWithCustomFormatter(): void
+    {
+        $parser = ParserBuilder::create()
+            ->withUsage('%prog [options]')
+            ->withProg('test')
+            ->build();
+
+        $formatter = HelpFormatter::create()->withWidth(40);
+        $help = $parser->formatHelp($formatter);
+
+        $this->assertIsString($help);
+        $this->assertStringContainsString('test', $help);
+    }
+
+    public function testParserFormatHelpWithDescription(): void
+    {
+        $parser = ParserBuilder::create()
+            ->withUsage('%prog')
+            ->withProg('test')
+            ->withDescription('This is a test program for demonstrations')
+            ->build();
+
+        $help = $parser->formatHelp();
+
+        $this->assertStringContainsString('This is a test program', $help);
+    }
+
+    public function testParserFormatHelpWithEpilog(): void
+    {
+        $parser = ParserBuilder::create()
+            ->withUsage('%prog')
+            ->withProg('test')
+            ->withEpilog('Report bugs to bugs@example.com')
+            ->build();
+
+        $help = $parser->formatHelp();
+
+        $this->assertStringContainsString('Report bugs', $help);
+    }
+
+    public function testParserFormatHelpCompleteExample(): void
+    {
+        $verbose = OptionBuilder::create()
+            ->short('-v')
+            ->long('--verbose')
+            ->counter()
+            ->help('Increase verbosity (-v, -vv, -vvv)')
+            ->build();
+
+        $port = OptionBuilder::create()
+            ->short('-p')
+            ->long('--port')
+            ->type(OptionType::Int)
+            ->default(8080)
+            ->help('Server port number')
+            ->build();
+
+        $format = OptionBuilder::create()
+            ->short('-f')
+            ->long('--format')
+            ->choices(['json', 'xml', 'csv'])
+            ->default('json')
+            ->help('Output format')
+            ->build();
+
+        $debugOption = OptionBuilder::create()
+            ->short('-d')
+            ->long('--debug')
+            ->flag()
+            ->help('Enable debug logging')
+            ->build();
+
+        $traceOption = OptionBuilder::create()
+            ->short('-t')
+            ->long('--trace')
+            ->flag()
+            ->help('Enable trace output')
+            ->build();
+
+        $debugGroup = GroupBuilder::create('Debugging Options')
+            ->withDescription('Options for troubleshooting and development')
+            ->addOption($debugOption)
+            ->addOption($traceOption)
+            ->build();
+
+        $parser = ParserBuilder::create()
+            ->withUsage('%prog [options] <input> <output>')
+            ->withProg('dataconverter')
+            ->withDescription('Convert data files between different formats')
+            ->withVersion('1.0.0')
+            ->withEpilog('For more information and examples, visit https://example.com/docs')
+            ->addOption($verbose)
+            ->addOption($port)
+            ->addOption($format)
+            ->addGroup($debugGroup)
+            ->build();
+
+        $help = $parser->formatHelp();
+
+        // Verify all major sections
+        $this->assertStringContainsString('Usage: dataconverter', $help);
+        $this->assertStringContainsString('Convert data files', $help);
+        $this->assertStringContainsString('Options:', $help);
+        $this->assertStringContainsString('--verbose', $help);
+        $this->assertStringContainsString('--port', $help);
+        $this->assertStringContainsString('--format', $help);
+        $this->assertStringContainsString('(default: 8080)', $help);
+        $this->assertStringContainsString('(default: json)', $help);
+        $this->assertStringContainsString("(choices: 'json', 'xml', 'csv')", $help);
+        $this->assertStringContainsString('Debugging Options:', $help);
+        $this->assertStringContainsString('--debug', $help);
+        $this->assertStringContainsString('--trace', $help);
+        $this->assertStringContainsString('https://example.com/docs', $help);
+    }
+
+    public function testParserFormatHelpUsesBuilderFormatter(): void
+    {
+        $formatter = HelpFormatter::create()->withWidth(60);
+
+        $parser = ParserBuilder::create()
+            ->withUsage('%prog')
+            ->withProg('test')
+            ->withHelpFormatter($formatter)
+            ->build();
+
+        $help = $parser->formatHelp();
+
+        $this->assertIsString($help);
+    }
+}

--- a/test/ImmutableParserTest.php
+++ b/test/ImmutableParserTest.php
@@ -536,7 +536,7 @@ class ImmutableParserTest extends TestCase
             '--port=3000',
             '--format', 'xml',
             'input.txt',
-            'output.txt'
+            'output.txt',
         ]);
 
         $this->assertSame(2, $result->options->get('verbosity'));
@@ -552,7 +552,7 @@ class ImmutableParserTest extends TestCase
 
         $builder = $parser->toBuilder();
 
-        $this->assertInstanceOf(\Horde\Argv\Modern\Builder\ParserBuilder::class, $builder);
+        $this->assertInstanceOf(ParserBuilder::class, $builder);
     }
 
     public function testToBuilderEnablesUseAndAmend(): void

--- a/test/Modern/Builder/ContextBuilderTest.php
+++ b/test/Modern/Builder/ContextBuilderTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2024-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Argv
+ */
+
+namespace Horde\Argv\Test\Modern\Builder;
+
+use Horde\Argv\Modern\Builder\{ContextBuilder, OptionBuilder};
+use Horde\Argv\Modern\Config\ContextConfig;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Tests for ContextBuilder.
+ *
+ * @category Horde
+ * @package  Argv
+ */
+#[CoversClass(ContextBuilder::class)]
+class ContextBuilderTest extends TestCase
+{
+    public function testCreateBasic(): void
+    {
+        $context = ContextBuilder::create('deploy')->build();
+
+        $this->assertInstanceOf(ContextConfig::class, $context);
+        $this->assertSame('deploy', $context->name);
+    }
+
+    public function testImmutability(): void
+    {
+        $builder1 = ContextBuilder::create('deploy');
+        $builder2 = $builder1->withDescription('Deploy app');
+
+        $this->assertNotSame($builder1, $builder2);
+
+        $context1 = $builder1->build();
+        $context2 = $builder2->build();
+
+        $this->assertSame('', $context1->description);
+        $this->assertSame('Deploy app', $context2->description);
+    }
+
+    public function testWithDescription(): void
+    {
+        $context = ContextBuilder::create('deploy')
+            ->withDescription('Deploy application to environment')
+            ->build();
+
+        $this->assertSame('Deploy application to environment', $context->description);
+    }
+
+    public function testWithUsage(): void
+    {
+        $context = ContextBuilder::create('deploy')
+            ->withUsage('%prog deploy [options] <env>')
+            ->build();
+
+        $this->assertSame('%prog deploy [options] <env>', $context->usage);
+    }
+
+    public function testWithHelp(): void
+    {
+        $context = ContextBuilder::create('deploy')
+            ->withHelp('Detailed help text')
+            ->build();
+
+        $this->assertSame('Detailed help text', $context->help);
+    }
+
+    public function testWithAliases(): void
+    {
+        $context = ContextBuilder::create('deploy')
+            ->withAliases(['dep', 'depl'])
+            ->build();
+
+        $this->assertSame(['dep', 'depl'], $context->aliases);
+    }
+
+    public function testAddOption(): void
+    {
+        $option = OptionBuilder::create()->long('--force')->flag()->build();
+
+        $context = ContextBuilder::create('deploy')
+            ->addOption($option)
+            ->build();
+
+        $this->assertCount(1, $context->options);
+        $this->assertSame($option, $context->options[0]);
+    }
+
+    public function testAddMultipleOptions(): void
+    {
+        $opt1 = OptionBuilder::create()->long('--force')->flag()->build();
+        $opt2 = OptionBuilder::create()->long('--timeout')->build();
+
+        $context = ContextBuilder::create('deploy')
+            ->addOption($opt1)
+            ->addOption($opt2)
+            ->build();
+
+        $this->assertCount(2, $context->options);
+    }
+
+    public function testAddOptions(): void
+    {
+        $opt1 = OptionBuilder::create()->long('--force')->flag()->build();
+        $opt2 = OptionBuilder::create()->long('--timeout')->build();
+
+        $context = ContextBuilder::create('deploy')
+            ->addOptions([$opt1, $opt2])
+            ->build();
+
+        $this->assertCount(2, $context->options);
+    }
+
+    public function testRequiresArguments(): void
+    {
+        $context = ContextBuilder::create('deploy')
+            ->requiresArguments(2, 'environment version')
+            ->build();
+
+        $this->assertSame(2, $context->minArgs);
+        $this->assertSame(2, $context->maxArgs);
+        $this->assertSame('environment version', $context->argsDescription);
+    }
+
+    public function testAcceptsArguments(): void
+    {
+        $context = ContextBuilder::create('deploy')
+            ->acceptsArguments(1, 3, 'files')
+            ->build();
+
+        $this->assertSame(1, $context->minArgs);
+        $this->assertSame(3, $context->maxArgs);
+        $this->assertSame('files', $context->argsDescription);
+    }
+
+    public function testAcceptsArgumentsUnlimited(): void
+    {
+        $context = ContextBuilder::create('process')
+            ->acceptsArguments(0, description: 'files')
+            ->build();
+
+        $this->assertSame(0, $context->minArgs);
+        $this->assertSame(PHP_INT_MAX, $context->maxArgs);
+    }
+
+    public function testRequiresExactly(): void
+    {
+        $context = ContextBuilder::create('deploy')
+            ->requiresExactly(1)
+            ->build();
+
+        $this->assertSame(1, $context->minArgs);
+        $this->assertSame(1, $context->maxArgs);
+    }
+
+    public function testRequiresAtLeast(): void
+    {
+        $context = ContextBuilder::create('deploy')
+            ->requiresAtLeast(2)
+            ->build();
+
+        $this->assertSame(2, $context->minArgs);
+        $this->assertSame(PHP_INT_MAX, $context->maxArgs);
+    }
+
+    public function testRequiresAtMost(): void
+    {
+        $context = ContextBuilder::create('deploy')
+            ->requiresAtMost(5)
+            ->build();
+
+        $this->assertSame(0, $context->minArgs);
+        $this->assertSame(5, $context->maxArgs);
+    }
+
+    public function testAddContext(): void
+    {
+        $subContext = ContextBuilder::create('start')->build();
+
+        $context = ContextBuilder::create('service')
+            ->addContext($subContext)
+            ->build();
+
+        $this->assertCount(1, $context->subContexts);
+        $this->assertSame($subContext, $context->subContexts[0]);
+    }
+
+    public function testFluentInterface(): void
+    {
+        $option = OptionBuilder::create()->long('--force')->flag()->build();
+
+        $context = ContextBuilder::create('deploy')
+            ->withDescription('Deploy application')
+            ->withUsage('%prog deploy <env>')
+            ->withAliases(['dep'])
+            ->addOption($option)
+            ->requiresArguments(1, 'environment')
+            ->build();
+
+        $this->assertSame('deploy', $context->name);
+        $this->assertSame('Deploy application', $context->description);
+        $this->assertSame('%prog deploy <env>', $context->usage);
+        $this->assertSame(['dep'], $context->aliases);
+        $this->assertCount(1, $context->options);
+        $this->assertSame(1, $context->minArgs);
+        $this->assertSame(1, $context->maxArgs);
+        $this->assertSame('environment', $context->argsDescription);
+    }
+
+    public function testNestedContexts(): void
+    {
+        $startContext = ContextBuilder::create('start')
+            ->withDescription('Start service')
+            ->build();
+
+        $stopContext = ContextBuilder::create('stop')
+            ->withDescription('Stop service')
+            ->build();
+
+        $serviceContext = ContextBuilder::create('service')
+            ->withDescription('Manage services')
+            ->addContext($startContext)
+            ->addContext($stopContext)
+            ->build();
+
+        $this->assertCount(2, $serviceContext->subContexts);
+        $this->assertSame('start', $serviceContext->subContexts[0]->name);
+        $this->assertSame('stop', $serviceContext->subContexts[1]->name);
+    }
+}

--- a/test/Modern/Builder/OptionBuilderTest.php
+++ b/test/Modern/Builder/OptionBuilderTest.php
@@ -225,7 +225,7 @@ class OptionBuilderTest extends TestCase
     public function testComplexOptionBuilding(): void
     {
         $validator = fn($v) => $v > 0 && $v < 65536;
-        $map = fn($v) => (int)$v;
+        $map = fn($v) => (int) $v;
 
         $config = OptionBuilder::create()
             ->short('-p')

--- a/test/Modern/Builder/ParserBuilderTest.php
+++ b/test/Modern/Builder/ParserBuilderTest.php
@@ -22,6 +22,7 @@ use Horde\Argv\Modern\Config\ParserConfig;
 use Horde\Argv\Modern\Enum\ConflictHandler;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use stdClass;
 
 #[CoversClass(ParserBuilder::class)]
 class ParserBuilderTest extends TestCase
@@ -319,7 +320,7 @@ class ParserBuilderTest extends TestCase
 
     public function testWithHelpFormatter(): void
     {
-        $formatter = new \stdClass(); // Placeholder for actual HelpFormatter
+        $formatter = new stdClass(); // Placeholder for actual HelpFormatter
 
         $parser = ParserBuilder::create()
             ->withHelpFormatter($formatter)

--- a/test/Modern/Config/ContextConfigTest.php
+++ b/test/Modern/Config/ContextConfigTest.php
@@ -19,6 +19,7 @@ namespace Horde\Argv\Test\Modern\Config;
 use Horde\Argv\Modern\Config\{ContextConfig, OptionConfig};
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use InvalidArgumentException;
 
 /**
  * Tests for ContextConfig.
@@ -70,7 +71,7 @@ class ContextConfigTest extends TestCase
 
     public function testEmptyNameThrows(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Context name cannot be empty');
 
         new ContextConfig(name: '');
@@ -78,7 +79,7 @@ class ContextConfigTest extends TestCase
 
     public function testNegativeMinArgsThrows(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('minArgs must be >= 0');
 
         new ContextConfig(name: 'test', minArgs: -1);
@@ -86,7 +87,7 @@ class ContextConfigTest extends TestCase
 
     public function testMaxArgsLessThanMinArgsThrows(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('maxArgs must be >= minArgs');
 
         new ContextConfig(name: 'test', minArgs: 5, maxArgs: 3);
@@ -202,7 +203,7 @@ class ContextConfigTest extends TestCase
 
     public function testNameCannotBeInAliases(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Context name cannot be in aliases list');
 
         new ContextConfig(name: 'deploy', aliases: ['deploy', 'dep']);

--- a/test/Modern/Config/ContextConfigTest.php
+++ b/test/Modern/Config/ContextConfigTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2024-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Argv
+ */
+
+namespace Horde\Argv\Test\Modern\Config;
+
+use Horde\Argv\Modern\Config\{ContextConfig, OptionConfig};
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Tests for ContextConfig.
+ *
+ * @category Horde
+ * @package  Argv
+ */
+#[CoversClass(ContextConfig::class)]
+class ContextConfigTest extends TestCase
+{
+    public function testBasicConstruction(): void
+    {
+        $context = new ContextConfig(name: 'deploy');
+
+        $this->assertSame('deploy', $context->name);
+        $this->assertSame('', $context->description);
+        $this->assertSame([], $context->aliases);
+        $this->assertSame([], $context->options);
+        $this->assertSame(0, $context->minArgs);
+        $this->assertSame(PHP_INT_MAX, $context->maxArgs);
+    }
+
+    public function testFullConstruction(): void
+    {
+        $option = new OptionConfig(long: '--force');
+
+        $context = new ContextConfig(
+            name: 'deploy',
+            description: 'Deploy application',
+            usage: '%prog deploy [options] <env>',
+            help: 'Deploys the application to an environment',
+            aliases: ['dep', 'depl'],
+            options: [$option],
+            minArgs: 1,
+            maxArgs: 2,
+            argsDescription: 'environment [version]'
+        );
+
+        $this->assertSame('deploy', $context->name);
+        $this->assertSame('Deploy application', $context->description);
+        $this->assertSame('%prog deploy [options] <env>', $context->usage);
+        $this->assertSame('Deploys the application to an environment', $context->help);
+        $this->assertSame(['dep', 'depl'], $context->aliases);
+        $this->assertCount(1, $context->options);
+        $this->assertSame(1, $context->minArgs);
+        $this->assertSame(2, $context->maxArgs);
+        $this->assertSame('environment [version]', $context->argsDescription);
+    }
+
+    public function testEmptyNameThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Context name cannot be empty');
+
+        new ContextConfig(name: '');
+    }
+
+    public function testNegativeMinArgsThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('minArgs must be >= 0');
+
+        new ContextConfig(name: 'test', minArgs: -1);
+    }
+
+    public function testMaxArgsLessThanMinArgsThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxArgs must be >= minArgs');
+
+        new ContextConfig(name: 'test', minArgs: 5, maxArgs: 3);
+    }
+
+    public function testMatchesName(): void
+    {
+        $context = new ContextConfig(name: 'deploy', aliases: ['dep']);
+
+        $this->assertTrue($context->matches('deploy'));
+        $this->assertTrue($context->matches('dep'));
+        $this->assertFalse($context->matches('rollback'));
+        $this->assertFalse($context->matches(''));
+    }
+
+    public function testGetAllNames(): void
+    {
+        $context = new ContextConfig(name: 'deploy', aliases: ['dep', 'depl']);
+
+        $names = $context->getAllNames();
+
+        $this->assertSame(['deploy', 'dep', 'depl'], $names);
+    }
+
+    public function testValidateArgumentCountExact(): void
+    {
+        $context = new ContextConfig(name: 'test', minArgs: 2, maxArgs: 2);
+
+        $this->assertFalse($context->validateArgumentCount(1));
+        $this->assertTrue($context->validateArgumentCount(2));
+        $this->assertFalse($context->validateArgumentCount(3));
+    }
+
+    public function testValidateArgumentCountRange(): void
+    {
+        $context = new ContextConfig(name: 'test', minArgs: 1, maxArgs: 3);
+
+        $this->assertFalse($context->validateArgumentCount(0));
+        $this->assertTrue($context->validateArgumentCount(1));
+        $this->assertTrue($context->validateArgumentCount(2));
+        $this->assertTrue($context->validateArgumentCount(3));
+        $this->assertFalse($context->validateArgumentCount(4));
+    }
+
+    public function testGetArgumentCountErrorExact(): void
+    {
+        $context = new ContextConfig(name: 'deploy', minArgs: 1, maxArgs: 1);
+
+        $error = $context->getArgumentCountError(0);
+        $this->assertStringContainsString('requires exactly 1 argument', $error);
+        $this->assertStringContainsString('got 0', $error);
+
+        $error = $context->getArgumentCountError(2);
+        $this->assertStringContainsString('requires exactly 1 argument', $error);
+        $this->assertStringContainsString('got 2', $error);
+    }
+
+    public function testGetArgumentCountErrorPlural(): void
+    {
+        $context = new ContextConfig(name: 'test', minArgs: 2, maxArgs: 2);
+
+        $error = $context->getArgumentCountError(1);
+        $this->assertStringContainsString('requires exactly 2 arguments', $error);
+    }
+
+    public function testGetArgumentCountErrorTooFew(): void
+    {
+        $context = new ContextConfig(name: 'deploy', minArgs: 2, maxArgs: 5);
+
+        $error = $context->getArgumentCountError(1);
+        $this->assertStringContainsString('requires at least 2 arguments', $error);
+        $this->assertStringContainsString('got 1', $error);
+    }
+
+    public function testGetArgumentCountErrorTooMany(): void
+    {
+        $context = new ContextConfig(name: 'deploy', minArgs: 1, maxArgs: 3);
+
+        $error = $context->getArgumentCountError(5);
+        $this->assertStringContainsString('accepts at most 3 arguments', $error);
+        $this->assertStringContainsString('got 5', $error);
+    }
+
+    public function testHasSubContexts(): void
+    {
+        $context1 = new ContextConfig(name: 'test');
+        $this->assertFalse($context1->hasSubContexts());
+
+        $subContext = new ContextConfig(name: 'sub');
+        $context2 = new ContextConfig(name: 'test', subContexts: [$subContext]);
+        $this->assertTrue($context2->hasSubContexts());
+    }
+
+    public function testFindSubContext(): void
+    {
+        $sub1 = new ContextConfig(name: 'start');
+        $sub2 = new ContextConfig(name: 'stop', aliases: ['halt']);
+
+        $context = new ContextConfig(name: 'service', subContexts: [$sub1, $sub2]);
+
+        $found = $context->findSubContext('start');
+        $this->assertSame('start', $found->name);
+
+        $found = $context->findSubContext('stop');
+        $this->assertSame('stop', $found->name);
+
+        $found = $context->findSubContext('halt');
+        $this->assertSame('stop', $found->name);
+
+        $found = $context->findSubContext('restart');
+        $this->assertNull($found);
+    }
+
+    public function testNameCannotBeInAliases(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Context name cannot be in aliases list');
+
+        new ContextConfig(name: 'deploy', aliases: ['deploy', 'dep']);
+    }
+}

--- a/test/Modern/Config/OptionConfigTest.php
+++ b/test/Modern/Config/OptionConfigTest.php
@@ -21,6 +21,7 @@ use Horde\Argv\Modern\Enum\{OptionAction, OptionType};
 use Horde\Argv\Modern\Exception\InvalidOptionException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionClass;
 
 #[CoversClass(OptionConfig::class)]
 class OptionConfigTest extends TestCase
@@ -193,7 +194,7 @@ class OptionConfigTest extends TestCase
     {
         $config = new OptionConfig(short: '-v');
 
-        $reflection = new \ReflectionClass($config);
+        $reflection = new ReflectionClass($config);
         $this->assertTrue($reflection->isReadOnly());
     }
 }

--- a/test/Modern/Help/HelpFormatterTest.php
+++ b/test/Modern/Help/HelpFormatterTest.php
@@ -1,0 +1,364 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2024-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Argv
+ */
+
+namespace Horde\Argv\Test\Modern\Help;
+
+use Horde\Argv\Modern\Help\HelpFormatter;
+use Horde\Argv\Modern\Config\{ParserConfig, OptionConfig, OptionGroupConfig};
+use Horde\Argv\Modern\Builder\{ParserBuilder, OptionBuilder, GroupBuilder};
+use Horde\Argv\Modern\Enum\{OptionType, OptionAction};
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(HelpFormatter::class)]
+class HelpFormatterTest extends TestCase
+{
+    public function testFormatterCanBeCreated(): void
+    {
+        $formatter = HelpFormatter::create();
+        $this->assertInstanceOf(HelpFormatter::class, $formatter);
+    }
+
+    public function testFormatterIsImmutable(): void
+    {
+        $formatter1 = HelpFormatter::create();
+        $formatter2 = $formatter1->withWidth(100);
+
+        $this->assertNotSame($formatter1, $formatter2);
+        $this->assertSame(80, $formatter1->getWidth());
+        $this->assertSame(100, $formatter2->getWidth());
+    }
+
+    public function testFormatUsageLine(): void
+    {
+        $config = new ParserConfig(
+            usage: '%prog [options] <file>',
+            prog: 'myapp'
+        );
+
+        $formatter = HelpFormatter::create();
+        $help = $formatter->format($config);
+
+        $this->assertStringContainsString('Usage: myapp [options] <file>', $help);
+    }
+
+    public function testFormatDescription(): void
+    {
+        $config = new ParserConfig(
+            usage: '%prog',
+            prog: 'test',
+            description: 'This is a test program'
+        );
+
+        $formatter = HelpFormatter::create();
+        $help = $formatter->format($config);
+
+        $this->assertStringContainsString('This is a test program', $help);
+    }
+
+    public function testFormatEpilog(): void
+    {
+        $config = new ParserConfig(
+            usage: '%prog',
+            prog: 'test',
+            epilog: 'Report bugs to bugs@example.com'
+        );
+
+        $formatter = HelpFormatter::create();
+        $help = $formatter->format($config);
+
+        $this->assertStringContainsString('Report bugs to bugs@example.com', $help);
+    }
+
+    public function testFormatSimpleOption(): void
+    {
+        $config = new ParserConfig(usage: '%prog', prog: 'test');
+        $option = OptionBuilder::create()
+            ->short('-v')
+            ->long('--verbose')
+            ->flag()
+            ->help('Enable verbose output')
+            ->build();
+
+        $formatter = HelpFormatter::create();
+        $help = $formatter->format($config, [$option]);
+
+        $this->assertStringContainsString('-v', $help);
+        $this->assertStringContainsString('--verbose', $help);
+        $this->assertStringContainsString('Enable verbose output', $help);
+    }
+
+    public function testFormatOptionWithArgument(): void
+    {
+        $config = new ParserConfig(usage: '%prog', prog: 'test');
+        $option = OptionBuilder::create()
+            ->short('-p')
+            ->long('--port')
+            ->type(OptionType::Int)
+            ->dest('port')
+            ->help('Server port')
+            ->build();
+
+        $formatter = HelpFormatter::create();
+        $help = $formatter->format($config, [$option]);
+
+        $this->assertStringContainsString('-p PORT', $help);
+        $this->assertStringContainsString('--port=PORT', $help);
+        $this->assertStringContainsString('Server port', $help);
+    }
+
+    public function testFormatOptionWithMetavar(): void
+    {
+        $config = new ParserConfig(usage: '%prog', prog: 'test');
+        $option = OptionBuilder::create()
+            ->short('-f')
+            ->long('--file')
+            ->metavar('FILE')
+            ->help('Input file')
+            ->build();
+
+        $formatter = HelpFormatter::create();
+        $help = $formatter->format($config, [$option]);
+
+        $this->assertStringContainsString('-f FILE', $help);
+        $this->assertStringContainsString('--file=FILE', $help);
+    }
+
+    public function testFormatOptionWithDefault(): void
+    {
+        $config = new ParserConfig(usage: '%prog', prog: 'test');
+        $option = OptionBuilder::create()
+            ->short('-p')
+            ->type(OptionType::Int)
+            ->dest('port')
+            ->default(8080)
+            ->help('Server port')
+            ->build();
+
+        $formatter = HelpFormatter::create();
+        $help = $formatter->format($config, [$option]);
+
+        $this->assertStringContainsString('(default: 8080)', $help);
+    }
+
+    public function testFormatOptionWithChoices(): void
+    {
+        $config = new ParserConfig(usage: '%prog', prog: 'test');
+        $option = OptionBuilder::create()
+            ->short('-f')
+            ->dest('format')
+            ->choices(['json', 'xml', 'csv'])
+            ->help('Output format')
+            ->build();
+
+        $formatter = HelpFormatter::create();
+        $help = $formatter->format($config, [$option]);
+
+        $this->assertStringContainsString("(choices: 'json', 'xml', 'csv')", $help);
+    }
+
+    public function testFormatOptionGroup(): void
+    {
+        $config = new ParserConfig(usage: '%prog', prog: 'test');
+
+        $debugOption = OptionBuilder::create()
+            ->short('-d')
+            ->long('--debug')
+            ->flag()
+            ->help('Enable debug mode')
+            ->build();
+
+        $group = GroupBuilder::create('Debugging Options')
+            ->withDescription('Options for debugging')
+            ->addOption($debugOption)
+            ->build();
+
+        $formatter = HelpFormatter::create();
+        $help = $formatter->format($config, [], [$group]);
+
+        $this->assertStringContainsString('Debugging Options:', $help);
+        $this->assertStringContainsString('Options for debugging', $help);
+        $this->assertStringContainsString('--debug', $help);
+    }
+
+    public function testFormatMultipleOptions(): void
+    {
+        $config = new ParserConfig(usage: '%prog', prog: 'test');
+
+        $verbose = OptionBuilder::create()->short('-v')->flag()->help('Verbose')->build();
+        $debug = OptionBuilder::create()->short('-d')->flag()->help('Debug')->build();
+        $quiet = OptionBuilder::create()->short('-q')->flag()->help('Quiet')->build();
+
+        $formatter = HelpFormatter::create();
+        $help = $formatter->format($config, [$verbose, $debug, $quiet]);
+
+        $this->assertStringContainsString('-v', $help);
+        $this->assertStringContainsString('-d', $help);
+        $this->assertStringContainsString('-q', $help);
+        $this->assertStringContainsString('Verbose', $help);
+        $this->assertStringContainsString('Debug', $help);
+        $this->assertStringContainsString('Quiet', $help);
+    }
+
+    public function testFormatCompleteHelp(): void
+    {
+        $config = new ParserConfig(
+            usage: '%prog [options] <input> <output>',
+            prog: 'converter',
+            description: 'Convert files between formats',
+            epilog: 'For more information, visit https://example.com'
+        );
+
+        $verbose = OptionBuilder::create()
+            ->short('-v')
+            ->long('--verbose')
+            ->counter()
+            ->help('Increase verbosity')
+            ->build();
+
+        $format = OptionBuilder::create()
+            ->short('-f')
+            ->long('--format')
+            ->dest('format')
+            ->choices(['json', 'xml'])
+            ->default('json')
+            ->help('Output format')
+            ->build();
+
+        $debugOption = OptionBuilder::create()
+            ->short('-d')
+            ->long('--debug')
+            ->flag()
+            ->help('Enable debug mode')
+            ->build();
+
+        $group = GroupBuilder::create('Debugging')
+            ->addOption($debugOption)
+            ->build();
+
+        $formatter = HelpFormatter::create()->withWidth(80);
+        $help = $formatter->format($config, [$verbose, $format], [$group]);
+
+        // Check all sections present
+        $this->assertStringContainsString('Usage: converter', $help);
+        $this->assertStringContainsString('Convert files between formats', $help);
+        $this->assertStringContainsString('Options:', $help);
+        $this->assertStringContainsString('--verbose', $help);
+        $this->assertStringContainsString('--format', $help);
+        $this->assertStringContainsString('Debugging:', $help);
+        $this->assertStringContainsString('--debug', $help);
+        $this->assertStringContainsString('https://example.com', $help);
+    }
+
+    public function testCustomWidth(): void
+    {
+        $formatter = HelpFormatter::create()->withWidth(40);
+        $this->assertSame(40, $formatter->getWidth());
+    }
+
+    public function testCustomIndent(): void
+    {
+        $config = new ParserConfig(usage: '%prog', prog: 'test');
+        $option = OptionBuilder::create()->short('-v')->flag()->help('Test')->build();
+
+        $formatter = HelpFormatter::create()->withIndent(4);
+        $help = $formatter->format($config, [$option]);
+
+        // Options should be indented with custom indent
+        $this->assertStringContainsString('    -v', $help);
+    }
+
+    public function testShortFirstOrdering(): void
+    {
+        $config = new ParserConfig(usage: '%prog', prog: 'test');
+        $option = OptionBuilder::create()
+            ->short('-v')
+            ->long('--verbose')
+            ->flag()
+            ->build();
+
+        $formatterShortFirst = HelpFormatter::create()->withShortFirst(true);
+        $helpShortFirst = $formatterShortFirst->format($config, [$option]);
+
+        $formatterLongFirst = HelpFormatter::create()->withShortFirst(false);
+        $helpLongFirst = $formatterLongFirst->format($config, [$option]);
+
+        // Both should contain both options
+        $this->assertStringContainsString('-v', $helpShortFirst);
+        $this->assertStringContainsString('--verbose', $helpShortFirst);
+        $this->assertStringContainsString('-v', $helpLongFirst);
+        $this->assertStringContainsString('--verbose', $helpLongFirst);
+    }
+
+    public function testBuildMethod(): void
+    {
+        $formatter = HelpFormatter::create()
+            ->withWidth(100)
+            ->withIndent(4)
+            ->build();
+
+        $this->assertInstanceOf(HelpFormatter::class, $formatter);
+        $this->assertSame(100, $formatter->getWidth());
+    }
+
+    public function testFormatOptionWithoutHelp(): void
+    {
+        $config = new ParserConfig(usage: '%prog', prog: 'test');
+        $option = OptionBuilder::create()
+            ->short('-v')
+            ->long('--verbose')
+            ->flag()
+            ->build();
+
+        $formatter = HelpFormatter::create();
+        $help = $formatter->format($config, [$option]);
+
+        $this->assertStringContainsString('-v', $help);
+        $this->assertStringContainsString('--verbose', $help);
+    }
+
+    public function testFormatShortOnlyOption(): void
+    {
+        $config = new ParserConfig(usage: '%prog', prog: 'test');
+        $option = OptionBuilder::create()
+            ->short('-v')
+            ->flag()
+            ->help('Verbose mode')
+            ->build();
+
+        $formatter = HelpFormatter::create();
+        $help = $formatter->format($config, [$option]);
+
+        $this->assertStringContainsString('-v', $help);
+        $this->assertStringContainsString('Verbose mode', $help);
+    }
+
+    public function testFormatLongOnlyOption(): void
+    {
+        $config = new ParserConfig(usage: '%prog', prog: 'test');
+        $option = OptionBuilder::create()
+            ->long('--verbose')
+            ->flag()
+            ->help('Verbose mode')
+            ->build();
+
+        $formatter = HelpFormatter::create();
+        $help = $formatter->format($config, [$option]);
+
+        $this->assertStringContainsString('--verbose', $help);
+        $this->assertStringContainsString('Verbose mode', $help);
+    }
+}

--- a/test/Modern/Result/OptionValuesTest.php
+++ b/test/Modern/Result/OptionValuesTest.php
@@ -19,6 +19,7 @@ namespace Horde\Argv\Test\Modern\Result;
 use Horde\Argv\Modern\Result\OptionValues;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionClass;
 
 #[CoversClass(OptionValues::class)]
 class OptionValuesTest extends TestCase
@@ -108,7 +109,7 @@ class OptionValuesTest extends TestCase
     {
         $values = new OptionValues(['test' => 'value']);
 
-        $reflection = new \ReflectionClass($values);
+        $reflection = new ReflectionClass($values);
         $this->assertTrue($reflection->isReadOnly());
     }
 

--- a/test/Modern/Result/ParseResultContextTest.php
+++ b/test/Modern/Result/ParseResultContextTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2024-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Argv
+ */
+
+namespace Horde\Argv\Test\Modern\Result;
+
+use Horde\Argv\Modern\Result\{ParseResult, OptionValues};
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Tests for ParseResult with context support.
+ *
+ * @category Horde
+ * @package  Argv
+ */
+#[CoversClass(ParseResult::class)]
+class ParseResultContextTest extends TestCase
+{
+    public function testLegacyModeWithoutContext(): void
+    {
+        $options = new OptionValues(['verbose' => true, 'port' => 8080]);
+        $result = new ParseResult(
+            options: $options,
+            arguments: ['file.txt'],
+            unknown: []
+        );
+
+        $this->assertFalse($result->hasContext());
+        $this->assertNull($result->getContext());
+        $this->assertNull($result->globalOptions);
+        $this->assertNull($result->contextOptions);
+
+        // Legacy access works
+        $this->assertTrue($result->options->get('verbose'));
+        $this->assertSame(8080, $result->options->get('port'));
+
+        // Convenience methods work in legacy mode
+        $this->assertTrue($result->getOption('verbose'));
+        $this->assertSame(8080, $result->getOption('port'));
+        $this->assertTrue($result->hasOption('verbose'));
+        $this->assertFalse($result->hasOption('missing'));
+    }
+
+    public function testContextModeWithActiveContext(): void
+    {
+        $global = new OptionValues(['verbose' => true]);
+        $context = new OptionValues(['force' => true, 'timeout' => 60]);
+
+        $result = new ParseResult(
+            options: new OptionValues([]),  // Not used in context mode
+            arguments: ['production'],
+            unknown: [],
+            globalOptions: $global,
+            contextOptions: $context,
+            context: 'deploy'
+        );
+
+        $this->assertTrue($result->hasContext());
+        $this->assertSame('deploy', $result->getContext());
+        $this->assertSame($global, $result->globalOptions);
+        $this->assertSame($context, $result->contextOptions);
+
+        // Context options accessible
+        $this->assertTrue($result->contextOptions->get('force'));
+        $this->assertSame(60, $result->contextOptions->get('timeout'));
+
+        // Global options accessible
+        $this->assertTrue($result->globalOptions->get('verbose'));
+    }
+
+    public function testGetOptionPriority(): void
+    {
+        // Context option should take priority over global
+        $global = new OptionValues(['verbose' => false, 'mode' => 'global']);
+        $context = new OptionValues(['verbose' => true]);
+
+        $result = new ParseResult(
+            options: new OptionValues([]),
+            arguments: [],
+            globalOptions: $global,
+            contextOptions: $context,
+            context: 'deploy'
+        );
+
+        // Context value takes priority
+        $this->assertTrue($result->getOption('verbose'));
+
+        // Falls back to global when not in context
+        $this->assertSame('global', $result->getOption('mode'));
+
+        // Returns default when missing
+        $this->assertSame('default', $result->getOption('missing', 'default'));
+    }
+
+    public function testHasOptionInContextMode(): void
+    {
+        $global = new OptionValues(['global_opt' => 'value']);
+        $context = new OptionValues(['context_opt' => 'value']);
+
+        $result = new ParseResult(
+            options: new OptionValues([]),
+            arguments: [],
+            globalOptions: $global,
+            contextOptions: $context,
+            context: 'deploy'
+        );
+
+        $this->assertTrue($result->hasOption('context_opt'));
+        $this->assertTrue($result->hasOption('global_opt'));
+        $this->assertFalse($result->hasOption('missing'));
+    }
+
+    public function testContextModeWithoutGlobalOptions(): void
+    {
+        $context = new OptionValues(['force' => true]);
+
+        $result = new ParseResult(
+            options: new OptionValues([]),
+            arguments: ['production'],
+            globalOptions: null,
+            contextOptions: $context,
+            context: 'deploy'
+        );
+
+        $this->assertTrue($result->hasContext());
+        $this->assertTrue($result->getOption('force'));
+        $this->assertNull($result->getOption('missing'));
+    }
+
+    public function testBackwardCompatibleArguments(): void
+    {
+        $options = new OptionValues(['verbose' => true]);
+
+        // Legacy mode
+        $result1 = new ParseResult(
+            options: $options,
+            arguments: ['file1.txt', 'file2.txt']
+        );
+
+        $this->assertTrue($result1->hasArguments());
+        $this->assertCount(2, $result1->arguments);
+        $this->assertSame('file1.txt', $result1->arguments[0]);
+
+        // Context mode
+        $result2 = new ParseResult(
+            options: new OptionValues([]),
+            arguments: ['production'],
+            globalOptions: new OptionValues([]),
+            contextOptions: new OptionValues(['force' => true]),
+            context: 'deploy'
+        );
+
+        $this->assertTrue($result2->hasArguments());
+        $this->assertCount(1, $result2->arguments);
+        $this->assertSame('production', $result2->arguments[0]);
+    }
+
+    public function testUnknownOptions(): void
+    {
+        $result = new ParseResult(
+            options: new OptionValues([]),
+            arguments: [],
+            unknown: ['--unknown', '--also-unknown']
+        );
+
+        $this->assertTrue($result->hasUnknown());
+        $this->assertCount(2, $result->unknown);
+        $this->assertSame('--unknown', $result->unknown[0]);
+    }
+
+    public function testNoContextNoGlobalNoContextOptions(): void
+    {
+        // Minimal result
+        $options = new OptionValues([]);
+        $result = new ParseResult(
+            options: $options,
+            arguments: []
+        );
+
+        $this->assertFalse($result->hasContext());
+        $this->assertFalse($result->hasArguments());
+        $this->assertFalse($result->hasUnknown());
+        $this->assertNull($result->getContext());
+    }
+}

--- a/test/Modern/Result/ParseResultTest.php
+++ b/test/Modern/Result/ParseResultTest.php
@@ -19,6 +19,7 @@ namespace Horde\Argv\Test\Modern\Result;
 use Horde\Argv\Modern\Result\{ParseResult, OptionValues};
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionClass;
 
 #[CoversClass(ParseResult::class)]
 class ParseResultTest extends TestCase
@@ -108,7 +109,7 @@ class ParseResultTest extends TestCase
     {
         $result = new ParseResult(new OptionValues([]), []);
 
-        $reflection = new \ReflectionClass($result);
+        $reflection = new ReflectionClass($result);
         $this->assertTrue($reflection->isReadOnly());
     }
 

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -10,4 +10,4 @@ foreach ($candidates as $candidate) {
         require_once $candidate;
     }
 }
-\Horde_Test_Bootstrap::bootstrap(dirname(__FILE__));
+Horde_Test_Bootstrap::bootstrap(dirname(__FILE__));


### PR DESCRIPTION
Applies PHP CS Fixer modernization: array() → [], const → public const, copyright year updates to 2026. Covers 105 files across entire codebase for consistency with Horde 6 standards.